### PR TITLE
Catch too early calls on windows and return an error instead of panicking

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,7 @@ go 1.13
 
 require golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9
 
-require github.com/godbus/dbus/v5 v5.0.4
+require (
+	github.com/godbus/dbus/v5 v5.0.4
+	github.com/tevino/abool v1.2.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/godbus/dbus/v5 v5.0.4 h1:9349emZab16e7zQvpmsbtjc18ykshndd8y2PG3sgJbA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/tevino/abool v1.2.0 h1:heAkClL8H6w+mK5md9dzsuohKeXHUpY7Vw0ZCKW+huA=
+github.com/tevino/abool v1.2.0/go.mod h1:qc66Pna1RiIsPa7O4Egxxs9OqkuxDX55zznh9K07Tzg=
 golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9 h1:YTzHMGlqJu67/uEo1lBv0n3wBXhXNeUbB1XfN2vmTm0=
 golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/systray_windows.go
+++ b/systray_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package systray
@@ -15,6 +16,7 @@ import (
 	"syscall"
 	"unsafe"
 
+	"github.com/tevino/abool"
 	"golang.org/x/sys/windows"
 )
 
@@ -208,11 +210,13 @@ type winTray struct {
 
 	wmSystrayMessage,
 	wmTaskbarCreated uint32
+
+	initialized *abool.AtomicBool
 }
 
 // isReady checks if the tray as already been initialized. It is not goroutine safe with in regard to the initialization function, but prevents a panic when functions are called too early.
 func (t *winTray) isReady() bool {
-	return t.instance != windows.Handle(0)
+	return t.initialized.IsSet()
 }
 
 // Loads an image from file and shows it in tray.
@@ -260,7 +264,9 @@ func (t *winTray) setTooltip(src string) error {
 	return t.nid.modify()
 }
 
-var wt winTray
+var wt = winTray{
+	initialized: abool.New(),
+}
 
 // WindowProc callback function that processes messages sent to a window.
 // https://msdn.microsoft.com/en-us/library/windows/desktop/ms633573(v=vs.85).aspx
@@ -276,6 +282,7 @@ func (t *winTray) wndProc(hWnd windows.Handle, message uint32, wParam, lParam ui
 	)
 	switch message {
 	case WM_CREATE:
+		t.initialized.Set()
 		systrayReady()
 	case WM_COMMAND:
 		menuItemId := int32(wParam)


### PR DESCRIPTION
This PR improves developer experience on Windows.

Currently, when you call a function of the library too early, it just panics.

With this PR, it does a not-perfect - but good enough - ﻿check to prevent a panic and return an error instead. This makes it a lot easier for developers to understand what they are doing wrong and help them use this library effectively, instead of opening issues about a panic. ;)
