### PR TITLE
Support menu item icons on Linux

### DIFF
--- a/systray_menu_unix.go
+++ b/systray_menu_unix.go
@@ -12,9 +12,16 @@ import (
 	"fyne.io/systray/internal/generated/menu"
 )
 
-// SetIcon sets the icon of a menu item. Only works on macOS and Windows.
+// SetIcon sets the icon of a menu item.
 // iconBytes should be the content of .ico/.jpg/.png
 func (item *MenuItem) SetIcon(iconBytes []byte) {
+	instance.menuLock.Lock()
+	defer instance.menuLock.Unlock()
+	m, exists := findLayout(int32(item.id))
+	if exists {
+		m.V1["icon-data"] = dbus.MakeVariant(iconBytes)
+		refresh()
+	}
 }
 
 // copyLayout makes full copy of layout

--- a/systray_unix.go
+++ b/systray_unix.go
@@ -131,11 +131,12 @@ func SetTooltip(tooltipTitle string) {
 	}
 }
 
-// SetTemplateIcon sets the icon of a menu item as a template icon (on macOS). On Windows, it
-// falls back to the regular icon bytes and on Linux it does nothing.
+// SetTemplateIcon sets the icon of a menu item as a template icon (on macOS). On Windows and
+// Linux, it falls back to the regular icon bytes.
 // templateIconBytes and regularIconBytes should be the content of .ico for windows and
 // .ico/.jpg/.png for other platforms.
 func (item *MenuItem) SetTemplateIcon(templateIconBytes []byte, regularIconBytes []byte) {
+	item.SetIcon(regularIconBytes)
 }
 
 func setInternalLoop(_ bool) {


### PR DESCRIPTION
I found that interaction through D-BUS allows to show icons in menu for most DE of Linux (It was not available in getlantern/systray via AppIndicator API).

It works in 
- GNOME 3 (Ubuntu 2204) 

![image](https://user-images.githubusercontent.com/8654729/173807253-5ecbd976-f214-4027-ac3d-2f3205bbdb6d.png)

- KDE (Kubuntu 2204) 

![image](https://user-images.githubusercontent.com/8654729/173807337-0cb8b57b-af43-4e2d-9ba0-77b58fb00cc8.png)

- XFCE (Xubuntu 2204) 

![image](https://user-images.githubusercontent.com/8654729/173807432-638126cf-873d-4c2d-80ec-aa3ee5ad4f76.png)

- LXQt (Lubuntu 2204) 

![image](https://user-images.githubusercontent.com/8654729/173807479-6222d0f2-5e73-406e-a4ae-244c17e7c8d5.png)

- MATE (Ubuntu MATE 2204) It works even when the app icon is not shown due to [this issue](https://github.com/AyatanaIndicators/libayatana-appindicator/issues/47) in Ayatana indicator project.

![image](https://user-images.githubusercontent.com/8654729/173807868-5cf2a785-dc5f-4648-b22d-568a4793e2bb.png)

I'm sure that providing this feature for Linux is important as it is already available for macOS and Windows.
