### PR TITLE
Cleanly quit systray when app exits

### DIFF
--- a/systray.go
+++ b/systray.go
@@ -80,7 +80,10 @@ func Run(onReady, onExit func()) {
 func RunWithExternalLoop(onReady, onExit func()) (start, end func()) {
 	Register(onReady, onExit)
 
-	return nativeStart, nativeEnd
+	return nativeStart, func() {
+		nativeEnd()
+		Quit()
+	}
 }
 
 // Register initializes GUI and registers the callbacks but relies on the


### PR DESCRIPTION
Fix report of windows app not removing system icon when exiting with external runloop