### PR TITLE
fix: fix icon transparency in menu items on Windows

### DIFF
--- a/systray_windows.go
+++ b/systray_windows.go
@@ -26,6 +26,7 @@ var (
 	g32                     = windows.NewLazySystemDLL("Gdi32.dll")
 	pCreateCompatibleBitmap = g32.NewProc("CreateCompatibleBitmap")
 	pCreateCompatibleDC     = g32.NewProc("CreateCompatibleDC")
+	pCreateDIBSection       = g32.NewProc("CreateDIBSection")
 	pDeleteDC               = g32.NewProc("DeleteDC")
 	pSelectObject           = g32.NewProc("SelectObject")
 
@@ -178,6 +179,30 @@ type menuItemInfo struct {
 // https://msdn.microsoft.com/en-us/library/windows/desktop/dd162805(v=vs.85).aspx
 type point struct {
 	X, Y int32
+}
+
+// The BITMAPINFO structure defines the dimensions and color information for a DIB.
+// https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapinfo
+type bitmapInfo struct {
+	BmiHeader bitmapInfoHeader
+	BmiColors windows.Handle
+}
+
+// The BITMAPINFOHEADER structure contains information about the dimensions and color format of a device-independent bitmap (DIB).
+// https://learn.microsoft.com/en-us/previous-versions/dd183376(v=vs.85)
+// https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapinfoheader
+type bitmapInfoHeader struct {
+	BiSize          uint32
+	BiWidth         int32
+	BiHeight        int32
+	BiPlanes        uint16
+	BiBitCount      uint16
+	BiCompression   uint32
+	BiSizeImage     uint32
+	BiXPelsPerMeter int32
+	BiYPelsPerMeter int32
+	BiClrUsed       uint32
+	BiClrImportant  uint32
 }
 
 // Contains information about loaded resources
@@ -776,7 +801,7 @@ func (t *winTray) loadIconFrom(src string) (windows.Handle, error) {
 	return h, nil
 }
 
-func (t *winTray) iconToBitmap(hIcon windows.Handle) (windows.Handle, error) {
+func iconToBitmap(hIcon windows.Handle) (windows.Handle, error) {
 	const SM_CXSMICON = 49
 	const SM_CYSMICON = 50
 	const DI_NORMAL = 0x3
@@ -792,10 +817,7 @@ func (t *winTray) iconToBitmap(hIcon windows.Handle) (windows.Handle, error) {
 	defer pDeleteDC.Call(hMemDC)
 	cx, _, _ := pGetSystemMetrics.Call(SM_CXSMICON)
 	cy, _, _ := pGetSystemMetrics.Call(SM_CYSMICON)
-	hMemBmp, _, err := pCreateCompatibleBitmap.Call(hDC, cx, cy)
-	if hMemBmp == 0 {
-		return 0, err
-	}
+	hMemBmp, err := create32BitHBitmap(hMemDC, int32(cx), int32(cy))
 	hOriginalBmp, _, _ := pSelectObject.Call(hMemDC, hMemBmp)
 	defer pSelectObject.Call(hMemDC, hOriginalBmp)
 	res, _, err := pDrawIconEx.Call(hMemDC, 0, 0, uintptr(hIcon), cx, cy, 0, uintptr(0), DI_NORMAL)
@@ -803,6 +825,35 @@ func (t *winTray) iconToBitmap(hIcon windows.Handle) (windows.Handle, error) {
 		return 0, err
 	}
 	return windows.Handle(hMemBmp), nil
+}
+
+// https://learn.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-createdibsection
+func create32BitHBitmap(hDC uintptr, cx, cy int32) (uintptr, error) {
+	const BI_RGB uint32 = 0
+	const DIB_RGB_COLORS = 0
+	bmi := bitmapInfo{
+		BmiHeader: bitmapInfoHeader{
+			BiPlanes:      1,
+			BiCompression: BI_RGB,
+			BiWidth:       cx,
+			BiHeight:      cy,
+			BiBitCount:    32,
+		},
+	}
+	bmi.BmiHeader.BiSize = uint32(unsafe.Sizeof(bmi.BmiHeader))
+	var bits uintptr
+	hBitmap, _, err := pCreateDIBSection.Call(
+		hDC,
+		uintptr(unsafe.Pointer(&bmi)),
+		DIB_RGB_COLORS,
+		uintptr(unsafe.Pointer(&bits)),
+		uintptr(0),
+		0,
+	)
+	if hBitmap == 0 {
+		return 0, err
+	}
+	return hBitmap, nil
 }
 
 func registerSystray() {
@@ -939,7 +990,7 @@ func (item *MenuItem) SetIcon(iconBytes []byte) {
 		return
 	}
 
-	h, err = wt.iconToBitmap(h)
+	h, err = iconToBitmap(h)
 	if err != nil {
 		log.Printf("systray error: unable to convert icon to bitmap: %s\n", err)
 		return


### PR DESCRIPTION
## Description

The current `iconToBitmap()` method in `systray_windows.go` uses the `CreateCompatibleBitmap()` Windows API [as suggested in Microsoft Learn](https://learn.microsoft.com/en-us/windows/win32/menurc/using-menus#creating-the-bitmap). But this method has a bug that makes the icon lose transparency information. This PR fixes the bug.

## Solution

Replace `CreateCompatibleBitmap()` with `CreateDIBSection()`. Usage from:

<https://osdn.net/projects/tortoisesvn/scm/svn/commits/14191>

## Related

- https://github.com/getlantern/systray/issues/207

- https://github.com/getlantern/systray/issues/192

- https://github.com/fleetdm/fleet/issues/6924

## Screenshots

Before:

![image](https://user-images.githubusercontent.com/20179549/196026660-feb7dce0-8484-455a-a33a-a0107314568b.png)

Fixed:

![image](https://user-images.githubusercontent.com/20179549/196026635-f5333664-4eac-488c-8691-2bc91b66d620.png)
