### PR TITLE
Forcefully delete the taskbar icon during quit on Windows

### DIFF
--- a/systray.go
+++ b/systray.go
@@ -10,10 +10,11 @@ import (
 )
 
 var (
-	systrayReady  func()
-	systrayExit   func()
-	menuItems     = make(map[uint32]*MenuItem)
-	menuItemsLock sync.RWMutex
+	systrayReady      func()
+	systrayExit       func()
+	systrayExitCalled bool
+	menuItems         = make(map[uint32]*MenuItem)
+	menuItemsLock     sync.RWMutex
 
 	currentID = uint32(0)
 	quitOnce  sync.Once
@@ -111,6 +112,7 @@ func Register(onReady func(), onExit func()) {
 		onExit = func() {}
 	}
 	systrayExit = onExit
+	systrayExitCalled = false
 	registerSystray()
 }
 

--- a/systray.go
+++ b/systray.go
@@ -20,6 +20,15 @@ var (
 	quitOnce  sync.Once
 )
 
+// This helper function allows us to call systrayExit only once,
+// without accidentally calling it twice in the same lifetime.
+func runSystrayExit() {
+	if !systrayExitCalled {
+		systrayExitCalled = true
+		systrayExit()
+	}
+}
+
 func init() {
 	runtime.LockOSThread()
 }

--- a/systray_darwin.go
+++ b/systray_darwin.go
@@ -144,10 +144,7 @@ func systray_ready() {
 
 //export systray_on_exit
 func systray_on_exit() {
-	if !systrayExitCalled {
-		systrayExitCalled = true
-		systrayExit()
-	}
+	runSystrayExit()
 }
 
 //export systray_menu_item_selected

--- a/systray_darwin.go
+++ b/systray_darwin.go
@@ -144,7 +144,10 @@ func systray_ready() {
 
 //export systray_on_exit
 func systray_on_exit() {
-	systrayExit()
+	if !systrayExitCalled {
+		systrayExitCalled = true
+		systrayExit()
+	}
 }
 
 //export systray_menu_item_selected

--- a/systray_unix.go
+++ b/systray_unix.go
@@ -154,10 +154,7 @@ func nativeLoop() int {
 }
 
 func nativeEnd() {
-	if !systrayExitCalled {
-		systrayExitCalled = true
-		systrayExit()
-	}
+	runSystrayExit()
 	instance.conn.Close()
 }
 

--- a/systray_unix.go
+++ b/systray_unix.go
@@ -154,7 +154,10 @@ func nativeLoop() int {
 }
 
 func nativeEnd() {
-	systrayExit()
+	if !systrayExitCalled {
+		systrayExitCalled = true
+		systrayExit()
+	}
 	instance.conn.Close()
 }
 

--- a/systray_windows.go
+++ b/systray_windows.go
@@ -951,6 +951,13 @@ func quit() {
 		0,
 		0,
 	)
+
+	wt.muNID.Lock()
+	if wt.nid != nil {
+		wt.nid.delete()
+	}
+	wt.muNID.Unlock()
+	systrayExit()
 }
 
 func setInternalLoop(bool) {

--- a/systray_windows.go
+++ b/systray_windows.go
@@ -324,10 +324,7 @@ func (t *winTray) wndProc(hWnd windows.Handle, message uint32, wParam, lParam ui
 			t.nid.delete()
 		}
 		t.muNID.Unlock()
-		if !systrayExitCalled {
-			systrayExitCalled = true
-			systrayExit()
-		}
+		runSystrayExit()
 	case t.wmSystrayMessage:
 		switch lParam {
 		case WM_RBUTTONUP, WM_LBUTTONUP:
@@ -960,10 +957,7 @@ func quit() {
 		wt.nid.delete()
 	}
 	wt.muNID.Unlock()
-	if !systrayExitCalled {
-		systrayExitCalled = true
-		systrayExit()
-	}
+	runSystrayExit()
 }
 
 func setInternalLoop(bool) {

--- a/systray_windows.go
+++ b/systray_windows.go
@@ -324,7 +324,10 @@ func (t *winTray) wndProc(hWnd windows.Handle, message uint32, wParam, lParam ui
 			t.nid.delete()
 		}
 		t.muNID.Unlock()
-		systrayExit()
+		if !systrayExitCalled {
+			systrayExitCalled = true
+			systrayExit()
+		}
 	case t.wmSystrayMessage:
 		switch lParam {
 		case WM_RBUTTONUP, WM_LBUTTONUP:
@@ -957,7 +960,10 @@ func quit() {
 		wt.nid.delete()
 	}
 	wt.muNID.Unlock()
-	systrayExit()
+	if !systrayExitCalled {
+		systrayExitCalled = true
+		systrayExit()
+	}
 }
 
 func setInternalLoop(bool) {

--- a/systray_windows_test.go
+++ b/systray_windows_test.go
@@ -18,6 +18,7 @@ const iconFilePath = "example/icon/iconwin.ico"
 func TestBaseWindowsTray(t *testing.T) {
 	systrayReady = func() {}
 	systrayExit = func() {}
+	systrayExitCalled = false
 
 	runtime.LockOSThread()
 


### PR DESCRIPTION
Taskbar-only apps are currently hanging in the taskbar area after being closed.

This patch forcefully deletes the taskbar menu, finally removing the icon once and for all.