### PR TITLE
Fix seperator on darwin for root menu

### DIFF
--- a/systray_darwin.m
+++ b/systray_darwin.m
@@ -172,12 +172,14 @@ NSMenuItem *find_menu_item(NSMenu *ourMenu, NSNumber *menuId) {
 
 - (void) add_separator:(NSNumber*) parentMenuId
 {
-  NSMenuItem* menuItem = find_menu_item(menu, parentMenuId);
-  if (menuItem != NULL) {
-    [menuItem.submenu addItem: [NSMenuItem separatorItem]];
-  } else {
-    [menu addItem: [NSMenuItem separatorItem]];
+  if (parentMenuId.integerValue != 0) {
+    NSMenuItem* menuItem = find_menu_item(menu, parentMenuId);
+    if (menuItem != NULL) {
+      [menuItem.submenu addItem: [NSMenuItem separatorItem]];
+      return;
+    }
   }
+  [menu addItem: [NSMenuItem separatorItem]];
 }
 
 - (void) hide_menu_item:(NSNumber*) menuId


### PR DESCRIPTION
Root menu separators are broken since latest change.  It seems zero is not returning a null value for the menu item.