### PR TITLE
use dbus.SessionBus() instead of dbus.ConnectSessionBus() to reuse connection to dbus in app

### DIFF
--- a/systray_menu_unix.go
+++ b/systray_menu_unix.go
@@ -319,7 +319,7 @@ func refresh() {
 	dbusErr := instance.menuProps.Set("com.canonical.dbusmenu", "Version",
 		dbus.MakeVariant(instance.menuVersion))
 	if dbusErr != nil {
-		log.Printf("systray error: failed to update menu version: %s\n", dbusErr)
+		log.Printf("systray error: failed to update menu version: %v\n", dbusErr)
 		return
 	}
 	err := menu.Emit(instance.conn, &menu.Dbusmenu_LayoutUpdatedSignal{
@@ -329,7 +329,7 @@ func refresh() {
 		},
 	})
 	if err != nil {
-		log.Printf("systray error: failed to emit layout updated signal: %s\n", err)
+		log.Printf("systray error: failed to emit layout updated signal: %v\n", err)
 	}
 
 }

--- a/systray_unix.go
+++ b/systray_unix.go
@@ -164,18 +164,18 @@ func quit() {
 
 func nativeStart() {
 	systrayReady()
-	conn, _ := dbus.ConnectSessionBus()
-	if conn == nil {
-		log.Printf("systray error: failed to connect to DBus")
+	conn, err := dbus.SessionBus()
+	if err != nil {
+		log.Printf("systray error: failed to connect to DBus: %v\n", err)
 		return
 	}
-	err := notifier.ExportStatusNotifierItem(conn, path, &notifier.UnimplementedStatusNotifierItem{})
+	err = notifier.ExportStatusNotifierItem(conn, path, &notifier.UnimplementedStatusNotifierItem{})
 	if err != nil {
-		log.Printf("systray error: failed to export status notifier item: %s\n", err)
+		log.Printf("systray error: failed to export status notifier item: %v\n", err)
 	}
 	err = menu.ExportDbusmenu(conn, menuPath, instance)
 	if err != nil {
-		log.Printf("systray error: failed to export status notifier item: %s\n", err)
+		log.Printf("systray error: failed to export status notifier menu: %v\n", err)
 		return
 	}
 


### PR DESCRIPTION
and improved error handling a bit