### PR TITLE
add systray.TrayOpenedCh which is triggered every time user clicks system tray

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -40,6 +40,8 @@ func onReady() {
 		systray.SetTemplateIcon(icon.Data, icon.Data)
 		systray.SetTitle("Awesome App")
 		systray.SetTooltip("Pretty awesome棒棒嗒")
+		trayOpenedCount := 0
+		mOpenedCount := systray.AddMenuItem("Tray opened count", "Tray opened count")
 		mChange := systray.AddMenuItem("Change Me", "Change Me")
 		mChecked := systray.AddMenuItemCheckbox("Checked", "Check Me", true)
 		mEnabled := systray.AddMenuItem("Enabled", "Enabled")
@@ -96,6 +98,9 @@ func onReady() {
 				addQuitItem()
 			case <-mToggle.ClickedCh:
 				toggle()
+			case <-systray.TrayOpenedCh:
+				trayOpenedCount++
+				mOpenedCount.SetTitle(fmt.Sprintf("Tray opened count: %d", trayOpenedCount))
 			}
 		}
 	}()

--- a/systray.go
+++ b/systray.go
@@ -20,6 +20,11 @@ var (
 	quitOnce  sync.Once
 )
 
+var (
+	// TrayOpenedCh is the channel which will be notified when system tray is shown. Only works on Linux and Windows.
+	TrayOpenedCh = make(chan struct{})
+)
+
 // This helper function allows us to call systrayExit only once,
 // without accidentally calling it twice in the same lifetime.
 func runSystrayExit() {

--- a/systray_menu_unix.go
+++ b/systray_menu_unix.go
@@ -99,9 +99,15 @@ func (t *tray) Event(id int32, eventID string, data dbus.Variant, timestamp uint
 	case "clicked":
 		systrayMenuItemSelected(uint32(id))
 	case "opened":
-		select {
-		case TrayOpenedCh <- struct{}{}:
-		default:
+		t.menuLock.RLock()
+		rootMenuID := t.menu.V0
+		t.menuLock.RUnlock()
+
+		if id == rootMenuID {
+			select {
+			case TrayOpenedCh <- struct{}{}:
+			default:
+			}
 		}
 	}
 	return

--- a/systray_menu_unix.go
+++ b/systray_menu_unix.go
@@ -95,8 +95,14 @@ func (t *tray) GetProperty(id int32, name string) (value dbus.Variant, err *dbus
 
 // Event is com.canonical.dbusmenu.Event method.
 func (t *tray) Event(id int32, eventID string, data dbus.Variant, timestamp uint32) (err *dbus.Error) {
-	if eventID == "clicked" {
+	switch eventID {
+	case "clicked":
 		systrayMenuItemSelected(uint32(id))
+	case "opened":
+		select {
+		case TrayOpenedCh <- struct{}{}:
+		default:
+		}
 	}
 	return
 }

--- a/systray_windows.go
+++ b/systray_windows.go
@@ -329,6 +329,11 @@ func (t *winTray) wndProc(hWnd windows.Handle, message uint32, wParam, lParam ui
 	case t.wmSystrayMessage:
 		switch lParam {
 		case WM_RBUTTONUP, WM_LBUTTONUP:
+			select {
+			case TrayOpenedCh <- struct{}{}:
+			default:
+			}
+
 			t.showMenu()
 		}
 	case t.wmTaskbarCreated: // on explorer.exe restarts


### PR DESCRIPTION
My use case is to refresh some data each time user clicks icon and update submenus

Unfortunately I don't have mac to implement it on darwin 

Probably related to #23 