### PR TITLE
Don't close the dbus session connection.

### DIFF
--- a/systray_unix.go
+++ b/systray_unix.go
@@ -151,7 +151,6 @@ func nativeLoop() int {
 
 func nativeEnd() {
 	runSystrayExit()
-	instance.conn.Close()
 }
 
 func quit() {


### PR DESCRIPTION
Don't close the dbus session connection when systray exits.

Per the dbus library's API documentation, you should not close a shared session connection. Drop that call when the systray is being shut down to avoid harming other users of the shared connection that may inhabit the same process and be longer lived.