### PR TITLE
Catch nil signal on window close

### DIFF
--- a/systray_unix.go
+++ b/systray_unix.go
@@ -265,6 +265,10 @@ func stayRegistered() {
 	for {
 		select {
 		case sig := <-sc:
+			if sig == nil {
+				return // We get a nil signal when closing the window.
+			}
+
 			// sig.Body has the args, which are [name old_owner new_owner]
 			if sig.Body[2] != "" {
 				register()


### PR DESCRIPTION
I can't say that I exactly know why we are getting this `nil` signal but simply catching it and returning fixes the issue.

Fixes https://github.com/fyne-io/fyne/issues/4074