### PR TITLE
ensure ID is not empty on linux

### DIFF
--- a/systray_unix.go
+++ b/systray_unix.go
@@ -298,7 +298,11 @@ type tray struct {
 
 func (t *tray) createPropSpec() map[string]map[string]*prop.Prop {
 	t.lock.Lock()
-	t.lock.Unlock()
+	defer t.lock.Unlock()
+	id := t.title
+	if id == "" {
+		id = fmt.Sprintf("systray_%d", os.Getpid())
+	}
 	return map[string]map[string]*prop.Prop{
 		"org.kde.StatusNotifierItem": {
 			"Status": {
@@ -314,7 +318,7 @@ func (t *tray) createPropSpec() map[string]map[string]*prop.Prop {
 				Callback: nil,
 			},
 			"Id": {
-				Value:    t.title,
+				Value:    id,
 				Writable: false,
 				Emit:     prop.EmitTrue,
 				Callback: nil,


### PR DESCRIPTION
Some desktop environments like the one provided by Ubuntu 22.04 requires the systray ID to be not empty to be displayed. This commit ensure the ID is always set trying to use the title and fallback to a default ID based on the pid.

Fixes fyne-io/fyne#3678