### PR TITLE
darwin: Stop the systray on quit rather than terminating the app

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -15,6 +15,7 @@ func main() {
 	}
 
 	systray.Run(onReady, onExit)
+	fmt.Println("Finished quitting")
 }
 
 func addQuitItem() {
@@ -24,7 +25,6 @@ func addQuitItem() {
 		<-mQuit.ClickedCh
 		fmt.Println("Requesting quit")
 		systray.Quit()
-		fmt.Println("Finished quitting")
 	}()
 	systray.AddSeparator()
 }

--- a/systray_darwin.m
+++ b/systray_darwin.m
@@ -227,7 +227,21 @@ NSMenuItem *find_menu_item(NSMenu *ourMenu, NSNumber *menuId) {
 
 - (void) quit
 {
-  [NSApp terminate:self];
+  // This tells the app event loop to stop after processing remaining messages.
+  [NSApp stop:self];
+  // The event loop won't return until it processes another event.
+  // https://stackoverflow.com/a/48064752/149482
+  NSPoint eventLocation = NSMakePoint(0, 0);
+  NSEvent *customEvent = [NSEvent otherEventWithType:NSEventTypeApplicationDefined
+                                            location:eventLocation
+                                       modifierFlags:0
+                                           timestamp:0
+                                        windowNumber:0
+                                             context:nil
+                                             subtype:0
+                                               data1:0
+                                               data2:0];
+  [NSApp postEvent:customEvent atStart:NO];
 }
 
 @end


### PR DESCRIPTION
On Darwin, quitting the systray terminates the current process. That's always been a pain. This stops the event loop, and systray.Run should return after calling systray.Quit.