### PR TITLE
[macOS] Allow setting status item interactive removal behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,11 @@ If bundling manually, you may want to add one or both of the following to your I
 
 Consult the [Official Apple Documentation here](https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFBundles/BundleTypes/BundleTypes.html#//apple_ref/doc/uid/10000123i-CH101-SW1).
 
+On macOS, it's possible to set the underlying
+[`NSStatusItemBehavior`](https://developer.apple.com/documentation/appkit/nsstatusitembehavior?language=objc)
+with `systray.SetRemovalAllowed(true)`. When enabled, the user can cmd-drag the
+icon off the menu bar.
+
 ## Credits
 
 - https://github.com/getlantern/systray

--- a/example/main.go
+++ b/example/main.go
@@ -43,6 +43,7 @@ func onReady() {
 		trayOpenedCount := 0
 		mOpenedCount := systray.AddMenuItem("Tray opened count", "Tray opened count")
 		mChange := systray.AddMenuItem("Change Me", "Change Me")
+		mAllowRemoval := systray.AddMenuItem("Allow removal", "macOS only: allow removal of the icon when cmd is pressed")
 		mChecked := systray.AddMenuItemCheckbox("Checked", "Check Me", true)
 		mEnabled := systray.AddMenuItem("Enabled", "Enabled")
 		// Sets the icon of a menu item. Only available on Mac.
@@ -86,6 +87,13 @@ func onReady() {
 					mChecked.Check()
 					mChecked.SetTitle("Checked")
 				}
+			case <-mAllowRemoval.ClickedCh:
+				systray.SetRemovalAllowed(true)
+				go func() {
+					time.Sleep(5 * time.Second)
+					fmt.Printf("Time's up! setting back to no-removal-allowed on macOS.\n")
+					systray.SetRemovalAllowed(false)
+				}()
 			case <-mEnabled.ClickedCh:
 				mEnabled.SetTitle("Disabled")
 				mEnabled.Disable()

--- a/systray.h
+++ b/systray.h
@@ -13,6 +13,7 @@ void setIcon(const char* iconBytes, int length, bool template);
 void setMenuItemIcon(const char* iconBytes, int length, int menuId, bool template);
 void setTitle(char* title);
 void setTooltip(char* tooltip);
+void setRemovalAllowed(bool allowed);
 void add_or_update_menu_item(int menuId, int parentMenuId, char* title, char* tooltip, short disabled, short checked, short isCheckable);
 void add_separator(int menuId, int parentId);
 void hide_menu_item(int menuId);

--- a/systray_darwin.go
+++ b/systray_darwin.go
@@ -42,6 +42,12 @@ func (item *MenuItem) SetTemplateIcon(templateIconBytes []byte, regularIconBytes
 	C.setMenuItemIcon(cstr, (C.int)(len(templateIconBytes)), C.int(item.id), true)
 }
 
+// SetRemovalAllowed sets whether a user can remove the systray icon or not.
+// This is only supported on macOS.
+func SetRemovalAllowed(allowed bool) {
+	C.setRemovalAllowed((C.bool)(allowed))
+}
+
 func registerSystray() {
 	C.registerSystray()
 }

--- a/systray_darwin.m
+++ b/systray_darwin.m
@@ -89,17 +89,18 @@ withParentMenuId: (int)theParentMenuId
   systray_on_exit();
 }
 
-- (void)setRemovalAllowed:(NSNumber *)allowedWrapped {
-  BOOL allowed = allowedWrapped.boolValue;
+- (void)setRemovalAllowed {
   NSStatusItemBehavior behavior = [self->statusItem behavior];
-  if (allowed) {
-    behavior |= NSStatusItemBehaviorRemovalAllowed;
-  } else {
-    behavior &= ~NSStatusItemBehaviorRemovalAllowed;
-    // Ensure the menu item is visible if it was removed, since we're now
-    // disallowing removal.
-    self->statusItem.visible = TRUE;
-  }
+  behavior |= NSStatusItemBehaviorRemovalAllowed;
+  self->statusItem.behavior = behavior;
+}
+
+- (void)setRemovalForbidden {
+  NSStatusItemBehavior behavior = [self->statusItem behavior];
+  behavior &= ~NSStatusItemBehaviorRemovalAllowed;
+  // Ensure the menu item is visible if it was removed, since we're now
+  // disallowing removal.
+  self->statusItem.visible = TRUE;
   self->statusItem.behavior = behavior;
 }
 
@@ -356,10 +357,11 @@ void setTooltip(char* ctooltip) {
 }
 
 void setRemovalAllowed(bool allowed) {
-  // must use an object wrapper for the bool, to use with
-  // performSelectorOnMainThread:
-  NSNumber *allow = [NSNumber numberWithBool:(BOOL)allowed];
-  runInMainThread(@selector(setRemovalAllowed:), (id)allow);
+  if (allowed) {
+    runInMainThread(@selector(setRemovalAllowed), nil);
+  } else {
+    runInMainThread(@selector(setRemovalForbidden), nil);
+  }
 }
 
 void add_or_update_menu_item(int menuId, int parentMenuId, char* title, char* tooltip, short disabled, short checked, short isCheckable) {

--- a/systray_unix.go
+++ b/systray_unix.go
@@ -134,6 +134,11 @@ func (item *MenuItem) SetTemplateIcon(templateIconBytes []byte, regularIconBytes
 	item.SetIcon(regularIconBytes)
 }
 
+// SetRemovalAllowed sets whether a user can remove the systray icon or not.
+// This is only supported on macOS.
+func SetRemovalAllowed(allowed bool) {
+}
+
 func setInternalLoop(_ bool) {
 	// nothing to action on Linux
 }

--- a/systray_windows.go
+++ b/systray_windows.go
@@ -541,6 +541,11 @@ func (t *winTray) convertToSubMenu(menuItemId uint32) (windows.Handle, error) {
 	return menu, nil
 }
 
+// SetRemovalAllowed sets whether a user can remove the systray icon or not.
+// This is only supported on macOS.
+func SetRemovalAllowed(allowed bool) {
+}
+
 func (t *winTray) addOrUpdateMenuItem(menuItemId uint32, parentId uint32, title string, disabled, checked bool) error {
 	if !wt.isReady() {
 		return ErrTrayNotReadyYet


### PR DESCRIPTION
This is largely bringing over https://github.com/getlantern/systray/pull/262 -- except there's a key fix in this version 🙂 (the `setRemovalAllowed` function as implemented in the original version is incorrectly using `BOOL` for the parameter instead of `NSNumber *`, which in practice means you can't ever set it back to false :P).

The new API is very basic but I didn't want to overdo it for a single-OS-specific feature anyway.