### PR TITLE
Add SetIconFromFilePath methods

### DIFF
--- a/systray_darwin.go
+++ b/systray_darwin.go
@@ -14,6 +14,7 @@ void setInternalLoop(bool);
 import "C"
 
 import (
+	"fmt"
 	"os"
 	"unsafe"
 )
@@ -32,6 +33,17 @@ func SetTemplateIcon(templateIconBytes []byte, regularIconBytes []byte) {
 func (item *MenuItem) SetIcon(iconBytes []byte) {
 	cstr := (*C.char)(unsafe.Pointer(&iconBytes[0]))
 	C.setMenuItemIcon(cstr, (C.int)(len(iconBytes)), C.int(item.id), false)
+}
+
+// SetIconFromFilePath sets the icon of a menu item from a file path.
+// iconFilePath should be the path to a .ico for windows and .ico/.jpg/.png for other platforms.
+func (item *MenuItem) SetIconFromFilePath(iconFilePath string) error {
+	iconBytes, err := os.ReadFile(iconFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to read icon file: %v", err)
+	}
+	item.SetIcon(iconBytes)
+	return nil
 }
 
 // SetTemplateIcon sets the icon of a menu item as a template icon (on macOS). On Windows, it

--- a/systray_darwin.go
+++ b/systray_darwin.go
@@ -98,7 +98,7 @@ func SetIcon(iconBytes []byte) {
 func SetIconFromFilePath(iconFilePath string) error {
 	bytes, err := os.ReadFile(iconFilePath)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to read icon file: %v", err)
 	}
 	SetIcon(bytes)
 	return nil

--- a/systray_darwin.go
+++ b/systray_darwin.go
@@ -14,6 +14,7 @@ void setInternalLoop(bool);
 import "C"
 
 import (
+	"os"
 	"unsafe"
 )
 
@@ -78,6 +79,17 @@ func setInternalLoop(internal bool) {
 func SetIcon(iconBytes []byte) {
 	cstr := (*C.char)(unsafe.Pointer(&iconBytes[0]))
 	C.setIcon(cstr, (C.int)(len(iconBytes)), false)
+}
+
+// SetIconFromFilePath sets the systray icon from a file path.
+// iconFilePath should be the path to a .ico for windows and .ico/.jpg/.png for other platforms.
+func SetIconFromFilePath(iconFilePath string) error {
+	bytes, err := os.ReadFile(iconFilePath)
+	if err != nil {
+		return err
+	}
+	SetIcon(bytes)
+	return nil
 }
 
 // SetTitle sets the systray title, only available on Mac and Linux.

--- a/systray_menu_unix.go
+++ b/systray_menu_unix.go
@@ -3,7 +3,9 @@
 package systray
 
 import (
+	"fmt"
 	"log"
+	"os"
 
 	"github.com/godbus/dbus/v5"
 	"github.com/godbus/dbus/v5/prop"
@@ -21,6 +23,17 @@ func (item *MenuItem) SetIcon(iconBytes []byte) {
 		m.V1["icon-data"] = dbus.MakeVariant(iconBytes)
 		refresh()
 	}
+}
+
+// SetIconFromFilePath sets the icon of a menu item from a file path.
+// iconFilePath should be the path to a .ico for windows and .ico/.jpg/.png for other platforms.
+func (item *MenuItem) SetIconFromFilePath(iconFilePath string) error {
+	iconBytes, err := os.ReadFile(iconFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to read icon file: %v", err)
+	}
+	item.SetIcon(iconBytes)
+	return nil
 }
 
 // copyLayout makes full copy of layout

--- a/systray_unix.go
+++ b/systray_unix.go
@@ -75,6 +75,17 @@ func SetIcon(iconBytes []byte) {
 	}
 }
 
+// SetIconFromFilePath sets the systray icon from a file path.
+// iconFilePath should be the path to a .ico for windows and .ico/.jpg/.png for other platforms.
+func SetIconFromFilePath(iconFilePath string) error {
+	bytes, err := os.ReadFile(iconFilePath)
+	if err != nil {
+		return err
+	}
+	SetIcon(bytes)
+	return nil
+}
+
 // SetTitle sets the systray title, only available on Mac and Linux.
 func SetTitle(t string) {
 	instance.lock.Lock()

--- a/systray_unix.go
+++ b/systray_unix.go
@@ -80,7 +80,7 @@ func SetIcon(iconBytes []byte) {
 func SetIconFromFilePath(iconFilePath string) error {
 	bytes, err := os.ReadFile(iconFilePath)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to read icon file: %v", err)
 	}
 	SetIcon(bytes)
 	return nil

--- a/systray_windows.go
+++ b/systray_windows.go
@@ -6,6 +6,7 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -1054,6 +1055,29 @@ func (item *MenuItem) SetIcon(iconBytes []byte) {
 		log.Printf("systray error: unable to addOrUpdateMenuItem: %s\n", err)
 		return
 	}
+}
+
+// SetIconFromFilePath sets the icon of a menu item from a file path.
+// iconFilePath should be the path to a .ico for windows and .ico/.jpg/.png for other platforms.
+func (item *MenuItem) SetIconFromFilePath(iconFilePath string) error {
+	h, err := wt.loadIconFrom(iconFilePath)
+	if err != nil {
+		return fmt.Errorf("unable to load icon from file: %s", err)
+	}
+
+	h, err = iconToBitmap(h)
+	if err != nil {
+		fmt.Errorf("unable to convert icon to bitmap: %s", err)
+	}
+	wt.muMenuItemIcons.Lock()
+	wt.menuItemIcons[uint32(item.id)] = h
+	wt.muMenuItemIcons.Unlock()
+
+	err = wt.addOrUpdateMenuItem(uint32(item.id), item.parentId(), item.title, item.disabled, item.checked)
+	if err != nil {
+		return fmt.Errorf("unable to addOrUpdateMenuItem: %s", err)
+	}
+	return nil
 }
 
 // SetTooltip sets the systray tooltip to display on mouse hover of the tray icon,

--- a/systray_windows.go
+++ b/systray_windows.go
@@ -1035,24 +1035,9 @@ func (item *MenuItem) SetIcon(iconBytes []byte) {
 		return
 	}
 
-	h, err := wt.loadIconFrom(iconFilePath)
+	err := wt.SetIconFromFilePath(iconFilePath)
 	if err != nil {
-		log.Printf("systray error: unable to load icon from temp file: %s\n", err)
-		return
-	}
-
-	h, err = iconToBitmap(h)
-	if err != nil {
-		log.Printf("systray error: unable to convert icon to bitmap: %s\n", err)
-		return
-	}
-	wt.muMenuItemIcons.Lock()
-	wt.menuItemIcons[uint32(item.id)] = h
-	wt.muMenuItemIcons.Unlock()
-
-	err = wt.addOrUpdateMenuItem(uint32(item.id), item.parentId(), item.title, item.disabled, item.checked)
-	if err != nil {
-		log.Printf("systray error: unable to addOrUpdateMenuItem: %s\n", err)
+		log.Printf("systray error: %s\n", err)
 		return
 	}
 }
@@ -1067,7 +1052,7 @@ func (item *MenuItem) SetIconFromFilePath(iconFilePath string) error {
 
 	h, err = iconToBitmap(h)
 	if err != nil {
-		fmt.Errorf("unable to convert icon to bitmap: %s", err)
+		return fmt.Errorf("unable to convert icon to bitmap: %s", err)
 	}
 	wt.muMenuItemIcons.Lock()
 	wt.menuItemIcons[uint32(item.id)] = h

--- a/systray_windows.go
+++ b/systray_windows.go
@@ -999,6 +999,12 @@ func SetIcon(iconBytes []byte) {
 	}
 }
 
+// SetIconFromFilePath sets the systray icon from a file path.
+// iconFilePath should be the path to a .ico for windows and .ico/.jpg/.png for other platforms.
+func SetIconFromFilePath(iconFilePath string) error {
+	return wt.setIcon(iconFilePath)
+}
+
 // SetTemplateIcon sets the systray icon as a template icon (on macOS), falling back
 // to a regular icon on other platforms.
 // templateIconBytes and iconBytes should be the content of .ico for windows and

--- a/systray_windows.go
+++ b/systray_windows.go
@@ -1003,7 +1003,11 @@ func SetIcon(iconBytes []byte) {
 // SetIconFromFilePath sets the systray icon from a file path.
 // iconFilePath should be the path to a .ico for windows and .ico/.jpg/.png for other platforms.
 func SetIconFromFilePath(iconFilePath string) error {
-	return wt.setIcon(iconFilePath)
+	err := wt.setIcon(iconFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to set icon: %v", err)
+	}
+	return nil
 }
 
 // SetTemplateIcon sets the systray icon as a template icon (on macOS), falling back
@@ -1035,7 +1039,7 @@ func (item *MenuItem) SetIcon(iconBytes []byte) {
 		return
 	}
 
-	err := wt.SetIconFromFilePath(iconFilePath)
+	err = item.SetIconFromFilePath(iconFilePath)
 	if err != nil {
 		log.Printf("systray error: %s\n", err)
 		return


### PR DESCRIPTION
This PR adds a global function and MenuItem methods called `SetIconFromFilePath` which sets the icon in the same way as the `SetIcon` methods but taking a file path to the icon and loading it as straightforwardly as possible. The methods work on all platforms.

Closes #86.