### PR TITLE
Remove child menu items before deleting item

### DIFF
--- a/systray.go
+++ b/systray.go
@@ -134,7 +134,7 @@ func ResetMenu() {
 	id := currentID.Load()
 	menuItemsLock.Unlock()
 	for i, item := range menuItems {
-		if i < id {
+		if i < id && item.parent == nil {
 			item.Remove()
 		}
 	}

--- a/systray.go
+++ b/systray.go
@@ -233,7 +233,7 @@ func (item *MenuItem) Hide() {
 // Remove removes a menu item
 func (item *MenuItem) Remove() {
 	menuItemsLock.RLock()
-	childList := make([]*MenuItem, 0, len(menuItems))
+	var childList []*MenuItem
 	for _, child := range menuItems {
 		if child.parent == item {
 			childList = append(childList, child)

--- a/systray.go
+++ b/systray.go
@@ -232,6 +232,17 @@ func (item *MenuItem) Hide() {
 
 // Remove removes a menu item
 func (item *MenuItem) Remove() {
+	menuItemsLock.RLock()
+	childList := make([]*MenuItem, 0, len(menuItems))
+	for _, child := range menuItems {
+		if child.parent == item {
+			childList = append(childList, child)
+		}
+	}
+	menuItemsLock.RUnlock()
+	for _, child := range childList {
+		child.Remove()
+	}
 	removeMenuItem(item)
 	menuItemsLock.Lock()
 	delete(menuItems, item.id)


### PR DESCRIPTION
On Windows, the demo application would log errors when the Reset item was clicked. This was because the items of the main menu and various submenus were deleted in a random order, such that items with a submenu were destroyed before the items in their respective child menus were.
```
2025/01/29 17:56:09 systray error: unable to hideMenuItem: Invalid menu handle.
2025/01/29 17:56:09 systray error: unable to addOrUpdateMenuItem: Invalid menu handle.
2025/01/29 17:56:09 systray error: unable to addOrUpdateMenuItem: Invalid menu handle.
2025/01/29 17:56:09 systray error: unable to addOrUpdateMenuItem: Invalid menu handle.
2025/01/29 17:56:09 systray error: unable to hideMenuItem: Invalid menu handle.
```
This PR fixes that by specifically deleting all child menu items before deleting parent items.