### PR TITLE
Return errors encountered during Register()/Run()

### DIFF
--- a/systray.go
+++ b/systray.go
@@ -80,7 +80,8 @@ func newMenuItem(title string, tooltip string, parent *MenuItem) *MenuItem {
 }
 
 // Run initializes GUI and starts the event loop, then invokes the onReady
-// callback. It blocks until systray.Quit() is called.
+// callback. It blocks until systray.Quit() is called. If an error us returned,
+// initialization failed and onReady/onExit will never be called
 func Run(onReady, onExit func()) error {
 	setInternalLoop(true)
 	err := Register(onReady, onExit)

--- a/systray.go
+++ b/systray.go
@@ -104,7 +104,7 @@ func RunWithExternalLoop(onReady, onExit func()) (start, end func()) {
 // needs to show other UI elements, for example, webview.
 // To overcome some OS weirdness, On macOS versions before Catalina, calling
 // this does exactly the same as Run().
-func Register(onReady func(), onExit func()) {
+func Register(onReady func(), onExit func()) error {
 	if onReady == nil {
 		systrayReady = func() {}
 	} else {
@@ -125,7 +125,7 @@ func Register(onReady func(), onExit func()) {
 	}
 	systrayExit = onExit
 	systrayExitCalled = false
-	registerSystray()
+	return registerSystray()
 }
 
 // ResetMenu will remove all menu items

--- a/systray.go
+++ b/systray.go
@@ -81,11 +81,14 @@ func newMenuItem(title string, tooltip string, parent *MenuItem) *MenuItem {
 
 // Run initializes GUI and starts the event loop, then invokes the onReady
 // callback. It blocks until systray.Quit() is called.
-func Run(onReady, onExit func()) {
+func Run(onReady, onExit func()) error {
 	setInternalLoop(true)
-	Register(onReady, onExit)
-
+	err := Register(onReady, onExit)
+	if err != nil {
+		return err
+	}
 	nativeLoop()
+	return nil
 }
 
 // RunWithExternalLoop allows the systemtray module to operate with other tookits.

--- a/systray.go
+++ b/systray.go
@@ -106,7 +106,8 @@ func RunWithExternalLoop(onReady, onExit func()) (start, end func()) {
 // caller to run the event loop somewhere else. It's useful if the program
 // needs to show other UI elements, for example, webview.
 // To overcome some OS weirdness, On macOS versions before Catalina, calling
-// this does exactly the same as Run().
+// this does exactly the same as Run(). If an error is returned, initialization
+// failed and onReady/onExit will never be called
 func Register(onReady func(), onExit func()) error {
 	if onReady == nil {
 		systrayReady = func() {}

--- a/systray_darwin.go
+++ b/systray_darwin.go
@@ -61,8 +61,9 @@ func SetRemovalAllowed(allowed bool) {
 	C.setRemovalAllowed((C.bool)(allowed))
 }
 
-func registerSystray() {
+func registerSystray() error {
 	C.registerSystray()
+	return nil
 }
 
 func nativeLoop() {

--- a/systray_unix.go
+++ b/systray_unix.go
@@ -154,7 +154,8 @@ func setInternalLoop(_ bool) {
 	// nothing to action on Linux
 }
 
-func registerSystray() {
+func registerSystray() error {
+	return nil
 }
 
 func nativeLoop() int {

--- a/systray_windows.go
+++ b/systray_windows.go
@@ -897,13 +897,14 @@ func create32BitHBitmap(hDC uintptr, cx, cy int32) (uintptr, error) {
 
 func registerSystray() error {
 	if err := wt.initInstance(); err != nil {
-		err = fmt.Errorf("systray error: unable to init instance: %s\n", err)
-		// TODO Log this too?
-		return err
+		err = fmt.Errorf("systray error: unable to init instance: %s", err)
+		log.Printf("%s\n", err)
+                return err
 	}
 
 	if err := wt.createMenu(); err != nil {
-		err = fmt.Errorf("systray error: unable to create menu: %s\n", err)
+		err = fmt.Errorf("systray error: unable to create menu: %s", err)
+                log.Printf("%s\n", err)
 		return err
 	}
 

--- a/systray_windows.go
+++ b/systray_windows.go
@@ -394,6 +394,9 @@ func (t *winTray) initInstance() error {
 	res, _, err := pRegisterWindowMessage.Call(
 		uintptr(unsafe.Pointer(taskbarEventNamePtr)),
 	)
+	if res == 0 {
+		return err
+	}
 	t.wmTaskbarCreated = uint32(res)
 
 	t.loadedImages = make(map[string]windows.Handle)
@@ -892,19 +895,21 @@ func create32BitHBitmap(hDC uintptr, cx, cy int32) (uintptr, error) {
 	return hBitmap, nil
 }
 
-func registerSystray() {
+func registerSystray() error {
 	if err := wt.initInstance(); err != nil {
-		log.Printf("systray error: unable to init instance: %s\n", err)
-		return
+		err = fmt.Errorf("systray error: unable to init instance: %s\n", err)
+		// TODO Log this too?
+		return err
 	}
 
 	if err := wt.createMenu(); err != nil {
-		log.Printf("systray error: unable to create menu: %s\n", err)
-		return
+		err = fmt.Errorf("systray error: unable to create menu: %s\n", err)
+		return err
 	}
 
 	wt.initialized.Store(true)
 	systrayReady()
+	return nil
 }
 
 var m = &struct {


### PR DESCRIPTION
Fixes https://github.com/fyne-io/systray/issues/95

I am only aware of this happening on Windows and even then the repro is difficult but this returns and error if one is encountered initializing the system tray since OnReady/OnExit will never be called. To maintain existing behavior I've kept the logging of the error as well which is a bit ugly but I think better than dropping it entirely