### PR TITLE
Allow hooks to Tapped and TappedSecondary

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"time"
 
 	"fyne.io/systray"
@@ -34,6 +35,11 @@ func onReady() {
 	systray.SetTooltip("Lantern")
 	addQuitItem()
 	systray.AddSeparator()
+
+	systray.SetOnSecondaryTapped(func() {
+		log.Println("Custom right click!")
+		systray.ShowMenu()
+	})
 
 	// We can manipulate the systray in other goroutines
 	go func() {

--- a/example/main.go
+++ b/example/main.go
@@ -38,7 +38,6 @@ func onReady() {
 
 	systray.SetOnSecondaryTapped(func() {
 		log.Println("Custom right click!")
-		systray.ShowMenu()
 	})
 
 	// We can manipulate the systray in other goroutines

--- a/systray.go
+++ b/systray.go
@@ -306,21 +306,3 @@ func systrayMenuItemSelected(id uint32) {
 	default:
 	}
 }
-
-func systrayLeftClick() {
-	if fn := tappedLeft; fn != nil {
-		fn()
-		return
-	}
-
-	ShowMenu()
-}
-
-func systrayRightClick() {
-	if fn := tappedRight; fn != nil {
-		fn()
-		return
-	}
-
-	ShowMenu()
-}

--- a/systray.go
+++ b/systray.go
@@ -10,11 +10,11 @@ import (
 )
 
 var (
-	systrayReady      func()
-	systrayExit       func()
-	systrayExitCalled bool
-	menuItems         = make(map[uint32]*MenuItem)
-	menuItemsLock     sync.RWMutex
+	systrayReady, systrayExit func()
+	tappedLeft, tappedRight   func()
+	systrayExitCalled         bool
+	menuItems                 = make(map[uint32]*MenuItem)
+	menuItemsLock             sync.RWMutex
 
 	currentID atomic.Uint32
 	quitOnce  sync.Once
@@ -144,6 +144,14 @@ func ResetMenu() {
 // Quit the systray
 func Quit() {
 	quitOnce.Do(quit)
+}
+
+func SetOnTapped(f func()) {
+	tappedLeft = f
+}
+
+func SetOnSecondaryTapped(f func()) {
+	tappedRight = f
 }
 
 // AddMenuItem adds a menu item with the designated title and tooltip.
@@ -297,4 +305,22 @@ func systrayMenuItemSelected(id uint32) {
 	// in case no one waiting for the channel
 	default:
 	}
+}
+
+func systrayLeftClick() {
+	if fn := tappedLeft; fn != nil {
+		fn()
+		return
+	}
+
+	ShowMenu()
+}
+
+func systrayRightClick() {
+	if fn := tappedRight; fn != nil {
+		fn()
+		return
+	}
+
+	ShowMenu()
 }

--- a/systray.go
+++ b/systray.go
@@ -88,7 +88,7 @@ func Run(onReady, onExit func()) {
 	nativeLoop()
 }
 
-// RunWithExternalLoop allows the systemtray module to operate with other tookits.
+// RunWithExternalLoop allows the system tray module to operate with other toolkits.
 // The returned start and end functions should be called by the toolkit when the application has started and will end.
 func RunWithExternalLoop(onReady, onExit func()) (start, end func()) {
 	Register(onReady, onExit)

--- a/systray.h
+++ b/systray.h
@@ -2,6 +2,8 @@
 
 extern void systray_ready();
 extern void systray_on_exit();
+extern void systray_left_click();
+extern void systray_right_click();
 extern void systray_menu_item_selected(int menu_id);
 extern void systray_menu_will_open();
 void registerSystray(void);
@@ -20,4 +22,5 @@ void hide_menu_item(int menuId);
 void remove_menu_item(int menuId);
 void show_menu_item(int menuId);
 void reset_menu();
+void show_menu();
 void quit();

--- a/systray_darwin.go
+++ b/systray_darwin.go
@@ -169,10 +169,6 @@ func resetMenu() {
 	C.reset_menu()
 }
 
-func ShowMenu() {
-	C.show_menu()
-}
-
 //export systray_left_click
 func systray_left_click() {
 	systrayLeftClick()

--- a/systray_darwin.go
+++ b/systray_darwin.go
@@ -171,12 +171,22 @@ func resetMenu() {
 
 //export systray_left_click
 func systray_left_click() {
-	systrayLeftClick()
+	if fn := tappedLeft; fn != nil {
+		fn()
+		return
+	}
+
+	C.show_menu()
 }
 
 //export systray_right_click
 func systray_right_click() {
-	systrayRightClick()
+	if fn := tappedRight; fn != nil {
+		fn()
+		return
+	}
+
+	C.show_menu()
 }
 
 //export systray_ready

--- a/systray_darwin.go
+++ b/systray_darwin.go
@@ -169,6 +169,20 @@ func resetMenu() {
 	C.reset_menu()
 }
 
+func ShowMenu() {
+	C.show_menu()
+}
+
+//export systray_left_click
+func systray_left_click() {
+	systrayLeftClick()
+}
+
+//export systray_right_click
+func systray_right_click() {
+	systrayRightClick()
+}
+
 //export systray_ready
 func systray_ready() {
 	systrayReady()

--- a/systray_darwin.m
+++ b/systray_darwin.m
@@ -115,11 +115,15 @@ withParentMenuId: (int)theParentMenuId
   }];
 
   NSSize size = [button frame].size;
-  NSRect frame = CGRectMake(0, 0, size.width*2, size.height);
+  NSRect frame = CGRectMake(0, 0, size.width, size.height);
   RightClickDetector *rightClicker = [[RightClickDetector alloc] initWithFrame:frame];
   rightClicker.onRightClicked = ^(NSEvent *event) {
     [self rightMouseClicked];
   };
+
+  rightClicker.autoresizingMask = (NSViewWidthSizable |
+                                   NSViewHeightSizable);
+  button.autoresizesSubviews = YES;
   [button addSubview:rightClicker];
 
   systray_ready();

--- a/systray_darwin.m
+++ b/systray_darwin.m
@@ -52,14 +52,33 @@ withParentMenuId: (int)theParentMenuId
 }
 @end
 
+@interface RightClickDetector : NSView
+
+@property (copy) void (^onRightClicked)(NSEvent *);
+
+@end
+
+@implementation RightClickDetector
+
+- (void)rightMouseUp:(NSEvent *)theEvent {
+  if (!self.onRightClicked) {
+    return;
+  }
+
+  self.onRightClicked(theEvent);
+}
+
+@end
+
+
 @interface SystrayAppDelegate: NSObject <NSApplicationDelegate, NSMenuDelegate>
   - (void) add_or_update_menu_item:(MenuItem*) item;
   - (IBAction)menuHandler:(id)sender;
   - (void)menuWillOpen:(NSMenu*)menu;
   @property (assign) IBOutlet NSWindow *window;
-  @end
+@end
 
-  @implementation SystrayAppDelegate
+@implementation SystrayAppDelegate
 {
   NSStatusItem *statusItem;
   NSMenu *menu;
@@ -75,13 +94,32 @@ withParentMenuId: (int)theParentMenuId
   self->menu = [[NSMenu alloc] init];
   self->menu.delegate = self;
   self->menu.autoenablesItems = FALSE;
-  self->statusItem.menu = self->menu;
   // Once the user has removed it, the item needs to be explicitly brought back,
   // even restarting the application is insufficient.
   // Since the interface from Go is relatively simple, for now we ensure it's
   // always visible at application startup.
   self->statusItem.visible = TRUE;
+
+  NSStatusBarButton *button = self->statusItem.button;
+  button.action = @selector(leftMouseClicked);
+
+  NSSize size = [button frame].size;
+  NSRect frame = CGRectMake(0, 0, size.width*2, size.height);
+  RightClickDetector *rightClicker = [[RightClickDetector alloc] initWithFrame:frame];
+  rightClicker.onRightClicked = ^(NSEvent *event) {
+    [self rightMouseClicked];
+  };
+  [button addSubview:rightClicker];
+
   systray_ready();
+}
+
+- (void)rightMouseClicked {
+  systray_right_click();
+}
+
+- (void)leftMouseClicked {
+  systray_left_click();
 }
 
 - (void)applicationWillTerminate:(NSNotification *)aNotification
@@ -228,6 +266,13 @@ NSMenuItem *find_menu_item(NSMenu *ourMenu, NSNumber *menuId) {
     return;
   }
   menuItem.image = image;
+}
+
+- (void)show_menu
+{
+  [self->menu popUpMenuPositioningItem:nil
+                            atLocation:NSMakePoint(0, self->statusItem.button.bounds.size.height+6)
+                                inView:self->statusItem.button];
 }
 
 - (void) show_menu_item:(NSNumber*) menuId
@@ -384,6 +429,10 @@ void hide_menu_item(int menuId) {
 void remove_menu_item(int menuId) {
   NSNumber *mId = [NSNumber numberWithInt:menuId];
   runInMainThread(@selector(remove_menu_item:), (id)mId);
+}
+
+void show_menu() {
+  runInMainThread(@selector(show_menu), nil);
 }
 
 void show_menu_item(int menuId) {

--- a/systray_darwin.m
+++ b/systray_darwin.m
@@ -103,6 +103,17 @@ withParentMenuId: (int)theParentMenuId
   NSStatusBarButton *button = self->statusItem.button;
   button.action = @selector(leftMouseClicked);
 
+  [NSEvent addLocalMonitorForEventsMatchingMask: (NSEventTypeLeftMouseDown|NSEventTypeRightMouseDown)
+                                        handler: ^NSEvent *(NSEvent *event) {
+    if (event.window != self->statusItem.button.window) {
+      return event;
+    }
+
+    [self leftMouseClicked];
+
+    return nil;
+  }];
+
   NSSize size = [button frame].size;
   NSRect frame = CGRectMake(0, 0, size.width*2, size.height);
   RightClickDetector *rightClicker = [[RightClickDetector alloc] initWithFrame:frame];

--- a/systray_notifier_unix.go
+++ b/systray_notifier_unix.go
@@ -13,15 +13,28 @@ func newLeftRightNotifierItem() notifier.StatusNotifierItemer {
 }
 
 func (i *leftRightNotifierItem) Activate(_, _ int32) *dbus.Error {
+	if f := tappedLeft; f == nil {
+		return &dbus.ErrMsgUnknownMethod
+	}
+
 	systrayLeftClick()
 	return nil
 }
 
 func (i *leftRightNotifierItem) ContextMenu(_, _ int32) *dbus.Error {
-	return &dbus.ErrMsgUnknownMethod
+	if f := tappedRight; f == nil {
+		return &dbus.ErrMsgUnknownMethod
+	}
+
+	systrayRightClick()
+	return nil
 }
 
 func (i *leftRightNotifierItem) SecondaryActivate(_, _ int32) *dbus.Error {
+	if f := tappedRight; f == nil {
+		return &dbus.ErrMsgUnknownMethod
+	}
+
 	systrayRightClick()
 	return nil
 }

--- a/systray_notifier_unix.go
+++ b/systray_notifier_unix.go
@@ -1,0 +1,31 @@
+package systray
+
+import (
+	"fyne.io/systray/internal/generated/notifier"
+	"github.com/godbus/dbus/v5"
+)
+
+type leftRightNotifierItem struct {
+}
+
+func newLeftRightNotifierItem() notifier.StatusNotifierItemer {
+	return &leftRightNotifierItem{}
+}
+
+func (i *leftRightNotifierItem) Activate(_, _ int32) *dbus.Error {
+	systrayLeftClick()
+	return nil
+}
+
+func (i *leftRightNotifierItem) ContextMenu(_, _ int32) *dbus.Error {
+	return &dbus.ErrMsgUnknownMethod
+}
+
+func (i *leftRightNotifierItem) SecondaryActivate(_, _ int32) *dbus.Error {
+	systrayRightClick()
+	return nil
+}
+
+func (i *leftRightNotifierItem) Scroll(_ int32, _ string) *dbus.Error {
+	return &dbus.ErrMsgUnknownMethod
+}

--- a/systray_notifier_unix.go
+++ b/systray_notifier_unix.go
@@ -17,7 +17,7 @@ func (i *leftRightNotifierItem) Activate(_, _ int32) *dbus.Error {
 		return &dbus.ErrMsgUnknownMethod
 	}
 
-	systrayLeftClick()
+	tappedLeft()
 	return nil
 }
 
@@ -26,7 +26,7 @@ func (i *leftRightNotifierItem) ContextMenu(_, _ int32) *dbus.Error {
 		return &dbus.ErrMsgUnknownMethod
 	}
 
-	systrayRightClick()
+	tappedRight()
 	return nil
 }
 
@@ -35,7 +35,7 @@ func (i *leftRightNotifierItem) SecondaryActivate(_, _ int32) *dbus.Error {
 		return &dbus.ErrMsgUnknownMethod
 	}
 
-	systrayRightClick()
+	tappedRight()
 	return nil
 }
 

--- a/systray_unix.go
+++ b/systray_unix.go
@@ -365,7 +365,7 @@ func (t *tray) createPropSpec() map[string]map[string]*prop.Prop {
 				Callback: nil,
 			},
 			"ItemIsMenu": {
-				Value:    true,
+				Value:    tappedLeft == nil && tappedRight == nil,
 				Writable: false,
 				Emit:     prop.EmitTrue,
 				Callback: nil,

--- a/systray_unix.go
+++ b/systray_unix.go
@@ -180,7 +180,7 @@ func nativeStart() {
 		log.Printf("systray error: failed to connect to DBus: %v\n", err)
 		return
 	}
-	err = notifier.ExportStatusNotifierItem(conn, path, &notifier.UnimplementedStatusNotifierItem{})
+	err = notifier.ExportStatusNotifierItem(conn, path, newLeftRightNotifierItem())
 	if err != nil {
 		log.Printf("systray error: failed to export status notifier item: %v\n", err)
 	}

--- a/systray_windows.go
+++ b/systray_windows.go
@@ -326,13 +326,10 @@ func (t *winTray) wndProc(hWnd windows.Handle, message uint32, wParam, lParam ui
 		runSystrayExit()
 	case t.wmSystrayMessage:
 		switch lParam {
-		case WM_RBUTTONUP, WM_LBUTTONUP:
-			select {
-			case TrayOpenedCh <- struct{}{}:
-			default:
-			}
-
-			t.showMenu()
+		case WM_LBUTTONUP:
+			systrayLeftClick()
+		case WM_RBUTTONUP:
+			systrayRightClick()
 		}
 	case t.wmTaskbarCreated: // on explorer.exe restarts
 		t.muNID.Lock()
@@ -1076,6 +1073,10 @@ func SetTooltip(tooltip string) {
 		log.Printf("systray error: unable to set tooltip: %s\n", err)
 		return
 	}
+}
+
+func ShowMenu() {
+	wt.showMenu()
 }
 
 func addOrUpdateMenuItem(item *MenuItem) {

--- a/systray_windows.go
+++ b/systray_windows.go
@@ -1127,3 +1127,21 @@ func resetMenu() {
 	wt.menuItemIcons = make(map[uint32]windows.Handle)
 	wt.createMenu()
 }
+
+func systrayLeftClick() {
+	if fn := tappedLeft; fn != nil {
+		fn()
+		return
+	}
+
+	wt.showMenu()
+}
+
+func systrayRightClick() {
+	if fn := tappedRight; fn != nil {
+		fn()
+		return
+	}
+
+	wt.showMenu()
+}

--- a/systray_windows.go
+++ b/systray_windows.go
@@ -1075,10 +1075,6 @@ func SetTooltip(tooltip string) {
 	}
 }
 
-func ShowMenu() {
-	wt.showMenu()
-}
-
 func addOrUpdateMenuItem(item *MenuItem) {
 	err := wt.addOrUpdateMenuItem(uint32(item.id), item.parentId(), item.title, item.disabled, item.checked)
 	if err != nil {


### PR DESCRIPTION
Without registered the previous menu will show (with the additional bug fix that Linux Left tap on some systems works again). Otherwise the Left/Right callbacks will be called instead of the default menu.
Be aware that on Linux neither are guaranteed to work as the implementation is fiercely differing in interpretations of the standard.
Thanks @zquestz for the Unix inspiration

Fixes #84 and #23