### PR TITLE
Avoid sending empty menus on startup

### DIFF
--- a/systray_menu_unix.go
+++ b/systray_menu_unix.go
@@ -59,6 +59,7 @@ func copyLayout(in *menuLayout, depth int32) *menuLayout {
 
 // GetLayout is com.canonical.dbusmenu.GetLayout method.
 func (t *tray) GetLayout(parentID int32, recursionDepth int32, propertyNames []string) (revision uint32, layout menuLayout, err *dbus.Error) {
+	initialMenuBuilt.Wait()
 	instance.menuLock.Lock()
 	defer instance.menuLock.Unlock()
 	if m, ok := findLayout(parentID); ok {
@@ -336,6 +337,8 @@ func showMenuItem(item *MenuItem) {
 }
 
 func refresh() {
+	instance.lock.Lock()
+	defer instance.lock.Unlock()
 	if instance.conn == nil || instance.menuProps == nil {
 		return
 	}


### PR DESCRIPTION
In Ubuntu 24.04, if the initial sent menu is empty, any subsequent updates to the menu will be ignored.

Lock responses on unix until the menu has initialized.

This was observed sporadically on Ubuntu 24.04 (and to a lesser degreee 25.04) for: https://github.com/tailscale/tailscale/tree/main/client/systray 