### PR TITLE
Prevent adding closed menu item

### DIFF
--- a/systray.go
+++ b/systray.go
@@ -135,9 +135,13 @@ func Register(onReady func(), onExit func()) {
 func ResetMenu() {
 	menuItemsLock.Lock()
 	id := currentID.Load()
+	items := make([]*MenuItem, 0, len(menuItems))
+	for _, item := range menuItems {
+		items = append(items, item)
+	}
 	menuItemsLock.Unlock()
-	for i, item := range menuItems {
-		if i < id && item.parent == nil {
+	for _, item := range items {
+		if item.id <= id && item.parent == nil {
 			item.Remove()
 		}
 	}

--- a/systray.go
+++ b/systray.go
@@ -68,7 +68,7 @@ func (item *MenuItem) String() string {
 
 // newMenuItem returns a populated MenuItem object
 func newMenuItem(title string, tooltip string, parent *MenuItem) *MenuItem {
-	return &MenuItem{
+	item := &MenuItem{
 		ClickedCh:   make(chan struct{}),
 		id:          currentID.Add(1),
 		title:       title,
@@ -78,6 +78,12 @@ func newMenuItem(title string, tooltip string, parent *MenuItem) *MenuItem {
 		isCheckable: false,
 		parent:      parent,
 	}
+
+	menuItemsLock.Lock()
+	menuItems[item.id] = item
+	menuItemsLock.Unlock()
+
+	return item
 }
 
 // Run initializes GUI and starts the event loop, then invokes the onReady
@@ -294,8 +300,12 @@ func (item *MenuItem) Uncheck() {
 // update propagates changes on a menu item to systray
 func (item *MenuItem) update() {
 	menuItemsLock.Lock()
-	menuItems[item.id] = item
+	_, exists := menuItems[item.id]
 	menuItemsLock.Unlock()
+
+	if !exists {
+		return
+	}
 	addOrUpdateMenuItem(item)
 }
 


### PR DESCRIPTION
Problem:
When an item is removed its click channel is closed. But if the item reference is still kept externally then any changes to it would add back the item, with a closed channel. Clicking on it would result in a crash.

Changes:
New items are added into menuItems. When an item is changed, before updating it, is checked if the item exists in menuItems. If is not, then returns an error.