### PR TITLE
Fix macOS status item drag and click handling

### DIFF
--- a/systray_darwin.m
+++ b/systray_darwin.m
@@ -91,6 +91,11 @@ withParentMenuId: (int)theParentMenuId
 {
   self->statusItem = [[NSStatusBar systemStatusBar] statusItemWithLength:NSVariableStatusItemLength];
 
+  NSString *bundleId = [[NSBundle mainBundle] bundleIdentifier];
+  if (bundleId) {
+    self->statusItem.autosaveName = bundleId;
+  }
+
   self->menu = [[NSMenu alloc] init];
   self->menu.delegate = self;
   self->menu.autoenablesItems = FALSE;
@@ -106,6 +111,10 @@ withParentMenuId: (int)theParentMenuId
   [NSEvent addLocalMonitorForEventsMatchingMask: (NSEventTypeLeftMouseDown|NSEventTypeRightMouseDown)
                                         handler: ^NSEvent *(NSEvent *event) {
     if (event.window != self->statusItem.button.window) {
+      return event;
+    }
+
+    if (event.modifierFlags & NSEventModifierFlagCommand) {
       return event;
     }
 


### PR DESCRIPTION
 ## Problem

 Status bar icons can become unclickable after being repositioned. Users also cannot Cmd+drag to reposition the icon.

  ## Changes

  1. Add `autosaveName` for position persistence
  2. Pass through Cmd+click to allow drag/reposition

  ## References
  - [autosaveName - Apple Docs](https://developer.apple.com/documentation/appkit/nsstatusitem/1644022-autosavename)