### PR TITLE
Change dbus path to make systray apps work as snaps

### DIFF
--- a/systray_unix.go
+++ b/systray_unix.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	path     = "/StatusNotifierItem"
-	menuPath = "/StatusNotifierMenu/menu"
+	menuPath = "/StatusNotifierItem/menu"
 )
 
 var (


### PR DESCRIPTION
This PR would fix #64

The `snapcraft.yaml` config will still require the following interfaces for your app based on my testing:

```yaml
apps:
  app-name:
      plugs:
        - desktop
        - desktop-legacy
```
