### PR TITLE
[BUGFIX] - Prevent closing already closed channel

### DIFF
--- a/systray.go
+++ b/systray.go
@@ -266,13 +266,21 @@ func (item *MenuItem) Remove() {
 	}
 	removeMenuItem(item)
 	menuItemsLock.Lock()
+	defer menuItemsLock.Unlock()
 	delete(menuItems, item.id)
+	if item.ClickedCh == nil {
+		log.Printf("systray warning: channel from menu item %d (%s) is nil!\n", item.id, item.title)
+		return
+	}
 	select {
-	case <-item.ClickedCh:
+	case _, ok := <-item.ClickedCh:
+		if !ok {
+			log.Printf("systray warning: channel from menu item %d (%s) already closed!\n", item.id, item.title)
+			return
+		}
 	default:
 	}
 	close(item.ClickedCh)
-	menuItemsLock.Unlock()
 }
 
 // Show shows a previously hidden menu item

--- a/systray.go
+++ b/systray.go
@@ -269,13 +269,11 @@ func (item *MenuItem) Remove() {
 	defer menuItemsLock.Unlock()
 	delete(menuItems, item.id)
 	if item.ClickedCh == nil {
-		log.Printf("systray warning: channel from menu item %d (%s) is nil!\n", item.id, item.title)
 		return
 	}
 	select {
 	case _, ok := <-item.ClickedCh:
 		if !ok {
-			log.Printf("systray warning: channel from menu item %d (%s) already closed!\n", item.id, item.title)
 			return
 		}
 	default:

--- a/systray_test.go
+++ b/systray_test.go
@@ -1,0 +1,96 @@
+package systray
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func TestMenuItem_Remove(t *testing.T) {
+	tests := []struct {
+		name string // description of this test case
+		// Named input parameters for receiver constructor.
+		menuItemFunc func() *MenuItem
+		checkFunc    func(*MenuItem) error // function to check the state of the menu item after removal
+	}{
+		{
+			name: "Remove a menu item with no children",
+			menuItemFunc: func() *MenuItem {
+				return AddMenuItem("Test Item", "Tooltip for test item")
+			},
+			checkFunc: func(item *MenuItem) error {
+				// Check if the item is removed from the menu
+				if len(menuItems) != 0 {
+					return fmt.Errorf("expected menuItems to be empty after removal, got: %v", menuItems)
+				}
+				return nil
+			},
+		},
+		{
+			name: "Remove a menu item with multiple children",
+			menuItemFunc: func() *MenuItem {
+				mainItem := AddMenuItem("Test Item", "Tooltip for test item")
+				mainItem.AddSubMenuItem("Child Item 1", "Tooltip for child item 1")
+				mainItem.AddSubMenuItem("Child Item 2", "Tooltip for child item 2")
+				return mainItem
+			},
+			checkFunc: func(item *MenuItem) error {
+				// Check if the item is removed from the menu
+				if len(menuItems) != 0 {
+					return fmt.Errorf("expected menuItems to be empty after removal, got: %v", menuItems)
+				}
+				return nil
+			},
+		},
+		{
+			name: "Remove a menu item with already channel set nil",
+			menuItemFunc: func() *MenuItem {
+				item := AddMenuItem("Test Item", "Tooltip for test item")
+				item.ClickedCh = nil
+				return item
+			},
+			checkFunc: func(item *MenuItem) error {
+				// Check if the item is removed from the menu
+				if len(menuItems) != 0 {
+					return fmt.Errorf("expected menuItems to be empty after removal, got: %v", menuItems)
+				}
+				return nil
+			},
+		},
+		{
+			name: "Remove a menu item with already closed channel",
+			menuItemFunc: func() *MenuItem {
+				item := AddMenuItem("Test Item", "Tooltip for test item")
+				close(item.ClickedCh)
+				return item
+			},
+			checkFunc: func(item *MenuItem) error {
+				// Check if the item is removed from the menu
+				if len(menuItems) != 0 {
+					return fmt.Errorf("expected menuItems to be empty after removal, got: %v", menuItems)
+				}
+				return nil
+			},
+		},
+	}
+	var wait sync.WaitGroup
+	wait.Add(1)
+	go Run(func() {
+		SetTitle("Test Tray")
+		SetTooltip("Test Tray Tooltip")
+		wait.Done()
+	}, nil)
+	wait.Wait()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ResetMenu()
+			var item *MenuItem
+			item = tt.menuItemFunc()
+			item.Remove()
+			if err := tt.checkFunc(item); err != nil {
+				t.Errorf("check failed: %v", err)
+			}
+		})
+	}
+	quit()
+}

--- a/systray_test.go
+++ b/systray_test.go
@@ -8,9 +8,8 @@ import (
 
 func TestMenuItem_Remove(t *testing.T) {
 	tests := []struct {
-		name string // description of this test case
-		// Named input parameters for receiver constructor.
-		menuItemFunc func() *MenuItem
+		name         string                // description of this test case
+		menuItemFunc func() *MenuItem      // function to create the menu item to be removed
 		checkFunc    func(*MenuItem) error // function to check the state of the menu item after removal
 	}{
 		{


### PR DESCRIPTION
### Problem ###

When calling systray.ResetMenu() we sometimes get an error from closing already closed item.ClickedCh

Normally, there is only one function in which this channel can be closed, but in our case, there seems to be a scenario where the item is not deleted, even though the channel has already been closed (the item is likely still referenced elsewhere and therefore not properly deleted).
When ResetMenu() is called, this item still exists, but the channel is already closed, which causes a panic.

### Changes ###

The select is checked for success, and the channel is closed only if the check is successful