### PR TITLE
fix(windows): destroy old HMENU handles before rebuild to prevent GDI handle leak

### DIFF
--- a/systray_windows.go
+++ b/systray_windows.go
@@ -483,6 +483,12 @@ func (t *winTray) initInstance() error {
 func (t *winTray) createMenu() error {
 	const MIM_APPLYTOSUBMENUS = 0x80000000 // Settings apply to the menu and all of its submenus
 
+	// Before creating a new menu, destroy the old one
+	if t.menus[0] != 0 {
+		pDestroyMenu.Call(uintptr(t.menus[0]))
+		t.menus[0] = 0
+	}
+
 	menuHandle, _, err := pCreatePopupMenu.Call()
 	if menuHandle == 0 {
 		return err


### PR DESCRIPTION
Calling Refresh() repeatedly leaked HMENU handles because CreatePopupMenu was called without first destroying the previous handle via DestroyMenu. On Windows USER object handles are limited (~10k per process), causing apps that refresh the systray menu frequently to eventually crash. Fixes fyne-io/fyne#3760