### PR TITLE
fix(darwin): use statusItem.menu + NSMenuDelegate for robust multi-display rendering

### DIFF
--- a/systray_darwin.m
+++ b/systray_darwin.m
@@ -285,8 +285,15 @@ NSMenuItem *find_menu_item(NSMenu *ourMenu, NSNumber *menuId) {
 
 - (void)show_menu
 {
+  // Anchor at (0, 0) of the status button so AppKit measures available vertical
+  // space from the menubar itself. The upstream value (0, height+6) places the
+  // menu's top ABOVE the button, which on MacBook notch displays (with the
+  // system-reserved safe area around the notch) makes AppKit decide the menu
+  // doesn't fit and flips it into scroll mode — a "^" arrow appears at the top
+  // and some rows are hidden. Anchoring at (0, 0) restores normal rendering
+  // on notch screens without changing behavior on external displays.
   [self->menu popUpMenuPositioningItem:nil
-                            atLocation:NSMakePoint(0, self->statusItem.button.bounds.size.height+6)
+                            atLocation:NSMakePoint(0, 0)
                                 inView:self->statusItem.button];
 }
 

--- a/systray_darwin.m
+++ b/systray_darwin.m
@@ -94,6 +94,14 @@ withParentMenuId: (int)theParentMenuId
   self->menu = [[NSMenu alloc] init];
   self->menu.delegate = self;
   self->menu.autoenablesItems = FALSE;
+  // 固定 minimumWidth 防止菜单宽度抖动:
+  // NSMenu 的"状态列"(checkmark indent)在所有 checkable item 都是 NSOffState
+  // 时会被 AppKit 收掉,菜单整体变窄;勾上某项后又突然展开。视觉上每次切
+  // 复选框 menu 都跳一下宽度。setShowsStateColumn 不是 NSMenu 的公共 API
+  // (我之前误用了,Obj-C 静默忽略),真正稳的做法是直接 pin 一个最小宽度。
+  // 220pt 够容下当前最长的菜单项("Open Settings…"+ tooltip 缓冲),也不会
+  // 显得太宽。后续菜单项变长再调。
+  self->menu.minimumWidth = 220.0;
   // Once the user has removed it, the item needs to be explicitly brought back,
   // even restarting the application is insufficient.
   // Since the interface from Go is relatively simple, for now we ensure it's

--- a/systray_darwin.m
+++ b/systray_darwin.m
@@ -100,33 +100,32 @@ withParentMenuId: (int)theParentMenuId
   // always visible at application startup.
   self->statusItem.visible = TRUE;
 
-  NSStatusBarButton *button = self->statusItem.button;
-  button.action = @selector(leftMouseClicked);
-
-  [NSEvent addLocalMonitorForEventsMatchingMask: (NSEventTypeLeftMouseDown|NSEventTypeRightMouseDown)
-                                        handler: ^NSEvent *(NSEvent *event) {
-    if (event.window != self->statusItem.button.window) {
-      return event;
-    }
-
-    [self leftMouseClicked];
-
-    return nil;
-  }];
-
-  NSSize size = [button frame].size;
-  NSRect frame = CGRectMake(0, 0, size.width, size.height);
-  RightClickDetector *rightClicker = [[RightClickDetector alloc] initWithFrame:frame];
-  rightClicker.onRightClicked = ^(NSEvent *event) {
-    [self rightMouseClicked];
-  };
-
-  rightClicker.autoresizingMask = (NSViewWidthSizable |
-                                   NSViewHeightSizable);
-  button.autoresizesSubviews = YES;
-  [button addSubview:rightClicker];
+  // Attach the menu permanently to the status item so AppKit handles display
+  // natively. This is the only way to get correct geometry when the system
+  // mirrors the menubar onto multiple screens ("Displays have separate Spaces"
+  // is on by default): each mirror's click pops the menu on its own display
+  // with proper available-height measurement. Synthesising clicks via
+  // performClick: on a primary-screen button and hoping AppKit forwards the
+  // popup to the clicked mirror doesn't work — the menu ends up measured
+  // against the wrong display and flips into NSMenu scroll mode ("^" arrow).
+  //
+  // Kopi only needs "left-click shows menu"; upstream systray's tappedLeft /
+  // tappedRight custom callback hooks are bypassed in this fork, which is an
+  // accepted trade for correct multi-display rendering.
+  self->statusItem.menu = self->menu;
 
   systray_ready();
+}
+
+// menuDidClose here is the fork's own NSMenuDelegate hook to drive the status
+// button highlight state. menuWillOpen for the same purpose is merged into
+// the existing menuWillOpen: further down that also fires Go's
+// systray_menu_will_open().
+- (void)menuDidClose:(NSMenu *)incomingMenu
+{
+  if (incomingMenu == self->menu) {
+    self->statusItem.button.highlighted = NO;
+  }
 }
 
 - (void)rightMouseClicked {
@@ -190,7 +189,16 @@ withParentMenuId: (int)theParentMenuId
   systray_menu_item_selected(menuId.intValue);
 }
 
-- (void)menuWillOpen:(NSMenu *)menu {
+- (void)menuWillOpen:(NSMenu *)incomingMenu {
+  // Kopi fork: drive the status button press-state highlight explicitly when
+  // our main menu opens. The native auto-highlight on NSStatusItem doesn't
+  // fire reliably under the statusItem.menu + mirrored-menubar path, so we
+  // toggle highlighted around menuWillOpen / menuDidClose. Scoped to the
+  // top-level menu only (submenus open with the same delegate but shouldn't
+  // re-toggle the status button state).
+  if (incomingMenu == self->menu) {
+    self->statusItem.button.highlighted = YES;
+  }
   systray_menu_will_open();
 }
 
@@ -285,16 +293,11 @@ NSMenuItem *find_menu_item(NSMenu *ourMenu, NSNumber *menuId) {
 
 - (void)show_menu
 {
-  // Anchor at (0, 0) of the status button so AppKit measures available vertical
-  // space from the menubar itself. The upstream value (0, height+6) places the
-  // menu's top ABOVE the button, which on MacBook notch displays (with the
-  // system-reserved safe area around the notch) makes AppKit decide the menu
-  // doesn't fit and flips it into scroll mode — a "^" arrow appears at the top
-  // and some rows are hidden. Anchoring at (0, 0) restores normal rendering
-  // on notch screens without changing behavior on external displays.
-  [self->menu popUpMenuPositioningItem:nil
-                            atLocation:NSMakePoint(0, 0)
-                                inView:self->statusItem.button];
+  // No-op in this fork: the menu is permanently attached to statusItem in
+  // applicationDidFinishLaunching, and AppKit presents it natively on click
+  // (including on mirrored menubars across multiple displays, which is why
+  // the synthesized-click path was removed). Kept for ABI compatibility with
+  // Go-side C.show_menu() callers who reach it via a tappedLeft fallback.
 }
 
 - (void) show_menu_item:(NSNumber*) menuId


### PR DESCRIPTION
## Problem

On macOS, the current `popUpMenuPositioningItem:atLocation:inView:` approach is fragile in two scenarios:

1. **MacBook notch displays**: the system-reserved safe area around the notch causes AppKit to underestimate available vertical space. The menu flips into scroll mode — a `^` arrow appears at the top and some items get hidden.
2. **Multi-display with mirrored menubars** (when "Displays have separate Spaces" is enabled in System Settings, which is the default): AppKit doesn't reliably route the popup to the clicked mirror. It measures available height against the wrong screen and flips into the same scroll mode.

Both symptoms look the same (`^` truncation), but they have different root causes. A previous revision of this PR only addressed #1 by changing the anchor to `(0, 0)`. That wasn't enough for #2.

## Fix

Attach the menu permanently to the status item via `statusItem.menu = self->menu` in `applicationDidFinishLaunching`. AppKit then handles click-to-open natively on each mirror with correct geometry measurement per display.

Consequences:
- Remove the manual `NSEvent addLocalMonitorForEventsMatchingMask` click interceptor.
- Remove `button.action = @selector(leftMouseClicked)`.
- Remove the `RightClickDetector` subview.
- `show_menu` becomes a no-op (kept for ABI compat with Go's `C.show_menu()` fallback callers).

The native-menu path also broke the status button's press-state auto-highlight. Restore it explicitly via `NSMenuDelegate`:
- `menuWillOpen:` → `button.highlighted = YES`
- `menuDidClose:` → `button.highlighted = NO`

Scoped to the top-level menu only, so submenus don't retrigger the status-button highlight.

## Trade-off

The existing `tappedLeft` / `tappedRight` custom-callback hooks are bypassed under this path — AppKit owns click handling now. Apps that rely on those hooks would regress. If upstream wants to land this, one option is gating the behavior behind a build tag or runtime switch; I'm happy to iterate on the shape.

## Testing

Verified on macOS 15 with:
- MacBook Pro built-in display with notch
- External 1920×1080 display above, mirrored menubar, dock on built-in
- "Displays have separate Spaces" both on and off

No `^` scroll mode in any configuration. Press-state highlight fires correctly when the menu opens on either screen.