### PR TITLE
Linux: emit ItemsPropertiesUpdated and refresh on item add

### DIFF
--- a/systray_menu_unix.go
+++ b/systray_menu_unix.go
@@ -21,6 +21,9 @@ func (item *MenuItem) SetIcon(iconBytes []byte) {
 	m, exists := findLayout(int32(item.id))
 	if exists {
 		m.V1["icon-data"] = dbus.MakeVariant(iconBytes)
+		emitItemPropertiesUpdated(int32(item.id), m.V1)
+		// Property-only change; per spec LayoutUpdated isn't required here,
+		// but kept as a fallback for clients that only watch LayoutUpdated.
 		refresh()
 	}
 }
@@ -193,6 +196,7 @@ type menuLayout = struct {
 
 func addOrUpdateMenuItem(item *MenuItem) {
 	var layout *menuLayout
+	var parentForChildrenDisplayUpdate *menuLayout
 	instance.menuLock.Lock()
 	defer instance.menuLock.Unlock()
 	m, exists := findLayout(int32(item.id))
@@ -210,7 +214,12 @@ func addOrUpdateMenuItem(item *MenuItem) {
 			m, ok := findLayout(int32(item.parent.id))
 			if ok {
 				parent = m
-				parent.V1["children-display"] = dbus.MakeVariant("submenu")
+				if _, already := parent.V1["children-display"]; !already {
+					parent.V1["children-display"] = dbus.MakeVariant("submenu")
+					if parent.V0 != 0 {
+						parentForChildrenDisplayUpdate = parent
+					}
+				}
 			}
 		}
 		parent.V2 = append(parent.V2, dbus.MakeVariant(layout))
@@ -218,6 +227,17 @@ func addOrUpdateMenuItem(item *MenuItem) {
 
 	applyItemToLayout(item, layout)
 	if exists {
+		emitItemPropertiesUpdated(int32(item.id), layout.V1)
+		// Property-only change on an existing item; per spec LayoutUpdated isn't required here,
+		// but kept as a fallback for clients that only watch LayoutUpdated.
+		refresh()
+	} else {
+		// We've added "children-display", that's a property change
+		if parentForChildrenDisplayUpdate != nil {
+			emitItemPropertiesUpdated(parentForChildrenDisplayUpdate.V0, parentForChildrenDisplayUpdate.V1)
+		}
+		// New item appended to a parent's children,
+		// that's a structural change, so LayoutUpdated signal is required
 		refresh()
 	}
 }
@@ -322,6 +342,9 @@ func hideMenuItem(item *MenuItem) {
 	m, exists := findLayout(int32(item.id))
 	if exists {
 		m.V1["visible"] = dbus.MakeVariant(false)
+		emitItemPropertiesUpdated(int32(item.id), m.V1)
+		// Property-only change; per spec LayoutUpdated isn't required here,
+		// but kept as a fallback for clients that only watch LayoutUpdated.
 		refresh()
 	}
 }
@@ -332,7 +355,34 @@ func showMenuItem(item *MenuItem) {
 	m, exists := findLayout(int32(item.id))
 	if exists {
 		m.V1["visible"] = dbus.MakeVariant(true)
+		emitItemPropertiesUpdated(int32(item.id), m.V1)
+		// Property-only change; per spec LayoutUpdated isn't required here,
+		// but kept as a fallback for clients that only watch LayoutUpdated.
 		refresh()
+	}
+}
+
+// emitItemPropertiesUpdated emits the com.canonical.dbusmenu.ItemsPropertiesUpdated
+// signal so desktop clients refresh per-item state (label, enabled, toggle-state,
+// visible, icon-data) without re-querying the whole layout.
+func emitItemPropertiesUpdated(id int32, props map[string]dbus.Variant) {
+	instance.lock.Lock()
+	conn := instance.conn
+	instance.lock.Unlock()
+	if conn == nil {
+		return
+	}
+	err := menu.Emit(conn, &menu.Dbusmenu_ItemsPropertiesUpdatedSignal{
+		Path: menuPath,
+		Body: &menu.Dbusmenu_ItemsPropertiesUpdatedSignalBody{
+			UpdatedProps: []struct {
+				V0 int32
+				V1 map[string]dbus.Variant
+			}{{V0: id, V1: props}},
+		},
+	})
+	if err != nil {
+		log.Printf("systray error: failed to emit items properties updated signal: %v\n", err)
 	}
 }
 


### PR DESCRIPTION
On Linux/AppIndicator the library only ever emitted Dbusmenu_LayoutUpdated. That signal is meant for *structural* changes — adding, removing, reparenting
items — and most desktop clients (KDE Plasma, gnome-shell-extension-appindicator, xfce4-panel) only re-fetch a layout when its revision changes. They do not re-poll item properties on a layout-version bump.

The result is that mutating an existing item via Check / Uncheck / SetTitle / Show / Hide / Enable / Disable / SetIcon updates the in-memory layout but the desktop side keeps showing stale state — checkboxes don't toggle, hidden items stay visible, titles don't update. This is particularly evident in submenus.

A separate, related bug: addOrUpdateMenuItem skipped refresh() when creating a new item (the `if exists { refresh() }` branch). For items added at startup this was harmless because the bus connection wasn't ready yet and refresh() is a no-op in that state — but for items added at runtime (dynamic submenus, growing list) the new item was invisible to the desktop until some unrelated update happened to trigger a refresh. addSeparator has always called refresh() unconditionally; bring addOrUpdateMenuItem in line.

Changes:

- Add emitItemPropertiesUpdated helper that fires the com.canonical.dbusmenu.ItemsPropertiesUpdated signal for a single item with its current property map. The generated bindings already had the signal type, just nobody was emitting it.
- Emit it from addOrUpdateMenuItem (update path), hideMenuItem, showMenuItem and SetIcon — every place that mutates V1 on an existing layout entry.
- Also emit it for the parent on first child-add, since that flips the parent's "children-display" property from absent to "submenu" and clients need to know the parent now renders as a submenu.
- Always call refresh() in addOrUpdateMenuItem, not only on update — newly added items are a structural change and need LayoutUpdated.

The existing refresh() calls in the property-only paths (hide / show / SetIcon and the update branch of addOrUpdateMenuItem) are kept as a fallback for any client that watches LayoutUpdated only, with comments noting they are technically redundant per spec. Could be removed in a follow-up.

Tested on Linux with my app: dynamic list submenu with Check / Uncheck / Show / Hide / SetTitle now reflects on the desktop in real time, on KDE Plasma.

Fixes #72. May be related to #99.

Disclosure: this is mostly AI-generated, but code has been reviewed, manually tested and spec verified by me.