### PR TITLE
fix(unix): fix blank submenus on libdbusmenu-gtk3 desktops (Cinnamon/Xfce/GNOME)

### DIFF
--- a/systray_menu_unix.go
+++ b/systray_menu_unix.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"time"
 
 	"github.com/godbus/dbus/v5"
 	"github.com/godbus/dbus/v5/prop"
@@ -60,14 +61,34 @@ func copyLayout(in *menuLayout, depth int32) *menuLayout {
 	return &out
 }
 
+// firstGetLayoutDone tracks whether the initial GetLayout response has been served
+// since the last menu reset. libdbusmenu-gtk3 (used by Cinnamon/Xfce/GNOME) requests
+// GetGroupProperties for grandchildren before parents in the first call, causing children
+// to be silently dropped (blank submenus) because parent GtkMenu containers don't exist
+// yet. Returning depth=1 on the first call ensures parents get their GtkMenu containers
+// before grandchildren are introduced in subsequent calls, where the order is correct.
+// After serving depth=1, a goroutine automatically triggers a second GetLayout cycle so
+// submenus populate without requiring user interaction. Multiple goroutines from rapid
+// resets are harmless — they just emit extra LayoutUpdated signals.
+var firstGetLayoutDone bool
+
 // GetLayout is com.canonical.dbusmenu.GetLayout method.
 func (t *tray) GetLayout(parentID int32, recursionDepth int32, propertyNames []string) (revision uint32, layout menuLayout, err *dbus.Error) {
 	initialMenuBuilt.Wait()
 	instance.menuLock.Lock()
 	defer instance.menuLock.Unlock()
 	if m, ok := findLayout(parentID); ok {
+		depth := recursionDepth
+		if !firstGetLayoutDone {
+			firstGetLayoutDone = true
+			depth = 1
+			go func() {
+				time.Sleep(150 * time.Millisecond)
+				refresh()
+			}()
+		}
 		// return copy of menu layout to prevent panic from cuncurrent access to layout
-		return instance.menuVersion, *copyLayout(m, recursionDepth), nil
+		return instance.menuVersion, *copyLayout(m, depth), nil
 	}
 	return
 }
@@ -151,6 +172,13 @@ func (t *tray) AboutToShow(id int32) (needUpdate bool, err *dbus.Error) {
 
 // AboutToShowGroup is com.canonical.dbusmenu.AboutToShowGroup method.
 func (t *tray) AboutToShowGroup(ids []int32) (updatesNeeded []int32, idErrors []int32, err *dbus.Error) {
+	instance.menuLock.RLock()
+	defer instance.menuLock.RUnlock()
+	for _, id := range ids {
+		if m, ok := findLayout(id); ok && len(m.V2) > 0 {
+			updatesNeeded = append(updatesNeeded, id)
+		}
+	}
 	return
 }
 
@@ -408,7 +436,6 @@ func refresh() {
 	if err != nil {
 		log.Printf("systray error: failed to emit layout updated signal: %v\n", err)
 	}
-
 }
 
 func resetMenu() {
@@ -416,5 +443,6 @@ func resetMenu() {
 	defer instance.menuLock.Unlock()
 	instance.menu = &menuLayout{}
 	instance.menuVersion++
+	firstGetLayoutDone = false
 	refresh()
 }


### PR DESCRIPTION
## Problem

On desktops using libdbusmenu-gtk3 (Cinnamon, Xfce, GNOME), submenus are permanently blank. The root cause is a specific ordering bug in libdbusmenu-gtk3's first `GetGroupProperties` call.

On the very first call after detecting a new tray service, libdbusmenu-gtk3 requests properties for grandchildren (depth-2 items) **before** parents (depth-1 items):

```
GetGroupProperties([25 26 27 28])        ← submenu children — FIRST
GetGroupProperties([12 13 14 15 ...])    ← more submenu children
GetGroupProperties([0 1 2 3 ... 24])     ← parent items — LAST
```

GTK tries to insert children into parent `GtkMenu` containers that don't exist yet, so they are silently dropped. All subsequent `GetLayout` cycles see these items as already-existing (update path, not create path), so they are never re-inserted. The result is permanently blank submenus.

On all subsequent `GetGroupProperties` calls the order is correct (parents before grandchildren), so the issue only manifests on the first call.

## Fix

Three minimal changes to `systray_menu_unix.go`:

**1. Return `depth=1` on the first `GetLayout` call** (`firstGetLayoutDone` flag)

Keeps grandchildren out of libdbusmenu's model in cycle 1. libdbusmenu creates `GtkMenu` containers for the parent items only. When the user opens a submenu, `AboutToShowGroup` triggers a second `GetLayout` call; the full tree is returned, grandchildren are new to the model, `GetGroupProperties` fires in the correct order (parents before grandchildren), and children are inserted into already-existing containers.

**2. `AboutToShowGroup` returns IDs of items that have children**

Previously a no-op. Now returns `updatesNeeded` for any item with children, causing libdbusmenu to call `GetLayout` before rendering a submenu (cycle 2).

**3. Reset `firstGetLayoutDone` in `resetMenu()`**

Ensures the fix re-applies after a menu rebuild (when the app calls `ResetMenu` to refresh tray contents).

## Testing

Tested on Linux Mint 22 (Cinnamon) against a real application ([NetBird](https://github.com/netbirdio/netbird)) with nested submenus. Submenus that were previously always blank now render correctly.