### PR TITLE
Position menu below the menu bar on macOS

### DIFF
--- a/systray_darwin.m
+++ b/systray_darwin.m
@@ -289,17 +289,19 @@ NSMenuItem *find_menu_item(NSMenu *ourMenu, NSNumber *menuId) {
 
 - (void)show_menu
 {
-  NSStatusBarButton *button = self->statusItem.button;
-  button.highlighted = YES;
-  // Anchor the menu to the bottom edge of the menu bar window (plus the
-  // native ~5pt gap), not the button: status buttons can be inset within
-  // the bar, so the button's own bottom may sit inside the menu bar.
-  NSPoint below = [button convertPoint:NSMakePoint(0, -5) fromView:nil];
-  below.x = 0;
-  [self->menu popUpMenuPositioningItem:nil
-                            atLocation:below
-                                inView:button];
-  button.highlighted = NO;
+  // Attach the menu and synthesize a click so AppKit positions it natively,
+  // then detach it in menuDidClose: so the next click reaches the button
+  // action (and the Go tap handlers) again.
+  self->statusItem.menu = self->menu;
+  [self->statusItem.button performClick:nil];
+}
+
+- (void)menuDidClose:(NSMenu *)menu {
+  // Defer the detach so we don't pull the menu out from under AppKit
+  // while it is still tearing the menu down.
+  dispatch_async(dispatch_get_main_queue(), ^{
+    self->statusItem.menu = nil;
+  });
 }
 
 - (void) show_menu_item:(NSNumber*) menuId

--- a/systray_darwin.m
+++ b/systray_darwin.m
@@ -289,11 +289,17 @@ NSMenuItem *find_menu_item(NSMenu *ourMenu, NSNumber *menuId) {
 
 - (void)show_menu
 {
-  self->statusItem.button.highlighted = YES;
+  NSStatusBarButton *button = self->statusItem.button;
+  button.highlighted = YES;
+  // Anchor the menu to the bottom edge of the menu bar window (plus the
+  // native ~5pt gap), not the button: status buttons can be inset within
+  // the bar, so the button's own bottom may sit inside the menu bar.
+  NSPoint below = [button convertPoint:NSMakePoint(0, -5) fromView:nil];
+  below.x = 0;
   [self->menu popUpMenuPositioningItem:nil
-                            atLocation:NSMakePoint(0, 0)
-                                inView:self->statusItem.button];
-  self->statusItem.button.highlighted = NO;
+                            atLocation:below
+                                inView:button];
+  button.highlighted = NO;
 }
 
 - (void) show_menu_item:(NSNumber*) menuId


### PR DESCRIPTION
## Problem

Since 969e8e6 ("fix: expand arrow on darwin"), `show_menu` pops the menu at `NSMakePoint(0, 0)` in the status bar button's coordinate system. `NSStatusBarButton` is a flipped view, so (0, 0) is its **top-left** — the menu's top edge gets pinned to the top of the menu bar.

On macOS 26 the result is:

- The menu opens **behind the menu bar**, with its first rows hidden and a phantom scroll arrow (the menu thinks part of itself is clipped)
- As soon as AppKit relayouts (e.g. scrolling the menu), it snaps down to a legal position below the bar, so the menu visibly jumps

## Fix

Anchor the menu to the bottom edge of the button's **window** (the menu bar) plus the native ~5pt gap, converting from window coordinates:

```objc
NSPoint below = [button convertPoint:NSMakePoint(0, -5) fromView:nil];
below.x = 0;
```

The window bottom — not the button's own bottom — is the right reference: status buttons can be inset within the bar (capsule-style status items), so `bounds.size.height` alone still leaves the menu overlapping the bar. This also avoids the hardcoded `+6` offset the pre-969e8e6 code used.

Tested on macOS 26 (Darwin 25.5): menu opens flush below the menu bar with the native gap, no jump, no phantom scroll arrows, regardless of menu length.