### PR TITLE
Fix crash on exit if system tray connection not established on Linux

### DIFF
--- a/systray_unix.go
+++ b/systray_unix.go
@@ -180,7 +180,9 @@ func nativeLoop() int {
 
 func nativeEnd() {
 	runSystrayExit()
-	instance.conn.Close()
+	if conn := instance.conn; conn != nil {
+		conn.Close()
+	}
 }
 
 func quit() {


### PR DESCRIPTION
Mitigates fyne-io/fyne/issues/6403