### PR TITLE
Renew the quit latch in Register so a second lifecycle can quit

### DIFF
--- a/systray.go
+++ b/systray.go
@@ -112,6 +112,12 @@ func RunWithExternalLoop(onReady, onExit func()) (start, end func()) {
 // To overcome some OS weirdness, On macOS versions before Catalina, calling
 // this does exactly the same as Run().
 func Register(onReady func(), onExit func()) {
+	// quitOnce guards a single tray lifecycle, but it is a package
+	// global that was only ever spent, never renewed - unlike
+	// systrayExitCalled, which is already cleared below. A second
+	// Register therefore came up with the latch used, so its Quit()
+	// was a silent no-op and the tray could not be stopped again.
+	quitOnce = sync.Once{}
 	if onReady == nil {
 		systrayReady = func() {}
 	} else {


### PR DESCRIPTION
## Problem

`quitOnce` is a package-global `sync.Once` consumed by `Quit()` via
`quitOnce.Do(quit)`. It is never reset, so an application that goes through a
second tray lifecycle - `Register` -> `Quit` -> `Register` (for example,
re-registering the tray icon after the host window is recreated) - ends up
with a spent latch: the second `Quit()` is a silent no-op and the message loop
never exits.

`Register()` already resets `systrayExitCalled` for exactly this
reuse scenario; `quitOnce` was missed.

## Fix

Reset `quitOnce` at the start of `Register()`, symmetric with the existing
`systrayExitCalled` reset. No API change; single hunk in the shared
`systray.go`, so all platforms behave the same.

Tested on Windows 10 (LTSC 2021): a production app that registers the tray,
quits, and re-registers now exits cleanly the second time; previously the
second `Quit()` did nothing. (Note: `go test ./...` does not currently compile
on Windows because `systray_windows_test.go` on master calls
`addOrUpdateMenuItem` with a stale signature - unrelated to this change.)
