### PR TITLE
Add SetOnDoubleTapped for the tray icon (Windows behavior)

### DIFF
--- a/systray.go
+++ b/systray.go
@@ -12,9 +12,13 @@ import (
 var (
 	systrayReady, systrayExit func()
 	tappedLeft, tappedRight   func()
-	systrayExitCalled         bool
-	menuItems                 = make(map[uint32]*MenuItem)
-	menuItemsLock             sync.RWMutex
+	// tappedDouble is read on the platform message-pump thread while
+	// the owner typically sets it from the onReady goroutine, so
+	// unlike the plain handlers above it is accessed atomically.
+	tappedDouble      atomic.Pointer[func()]
+	systrayExitCalled bool
+	menuItems         = make(map[uint32]*MenuItem)
+	menuItemsLock     sync.RWMutex
 
 	initialMenuBuilt sync.WaitGroup
 	currentID        atomic.Uint32
@@ -165,6 +169,25 @@ func SetOnTapped(f func()) {
 
 func SetOnSecondaryTapped(f func()) {
 	tappedRight = f
+}
+
+// SetOnDoubleTapped sets the handler for a left double-click on the tray
+// icon; a nil f clears it. Implemented on Windows; on other platforms
+// the handler is stored but never invoked.
+//
+// While a double-click handler is set and no SetOnTapped handler is,
+// a single left click does nothing, so the menu does not flash open
+// before the second click of a double-click arrives. A right click
+// still opens the menu.
+//
+// The handler runs on the tray message-pump thread. Keep it short or
+// hand the work to another goroutine.
+func SetOnDoubleTapped(f func()) {
+	if f == nil {
+		tappedDouble.Store(nil)
+		return
+	}
+	tappedDouble.Store(&f)
 }
 
 // AddMenuItem adds a menu item with the designated title and tooltip.

--- a/systray_windows.go
+++ b/systray_windows.go
@@ -296,12 +296,13 @@ var wt = winTray{}
 // https://msdn.microsoft.com/en-us/library/windows/desktop/ms633573(v=vs.85).aspx
 func (t *winTray) wndProc(hWnd windows.Handle, message uint32, wParam, lParam uintptr) (lResult uintptr) {
 	const (
-		WM_RBUTTONUP  = 0x0205
-		WM_LBUTTONUP  = 0x0202
-		WM_COMMAND    = 0x0111
-		WM_ENDSESSION = 0x0016
-		WM_CLOSE      = 0x0010
-		WM_DESTROY    = 0x0002
+		WM_RBUTTONUP     = 0x0205
+		WM_LBUTTONUP     = 0x0202
+		WM_LBUTTONDBLCLK = 0x0203
+		WM_COMMAND       = 0x0111
+		WM_ENDSESSION    = 0x0016
+		WM_CLOSE         = 0x0010
+		WM_DESTROY       = 0x0002
 	)
 	switch message {
 	case WM_COMMAND:
@@ -328,6 +329,8 @@ func (t *winTray) wndProc(hWnd windows.Handle, message uint32, wParam, lParam ui
 		switch lParam {
 		case WM_LBUTTONUP:
 			systrayLeftClick()
+		case WM_LBUTTONDBLCLK:
+			systrayDoubleClick()
 		case WM_RBUTTONUP:
 			systrayRightClick()
 		}
@@ -1131,6 +1134,21 @@ func resetMenu() {
 func systrayLeftClick() {
 	if fn := tappedLeft; fn != nil {
 		fn()
+		return
+	}
+	// With a double-click handler bound and no single-click one, keep
+	// a bare left click inert: opening the menu here would flash it
+	// open and shut between the two clicks of a double-click.
+	if tappedDouble.Load() != nil {
+		return
+	}
+
+	wt.showMenu()
+}
+
+func systrayDoubleClick() {
+	if fn := tappedDouble.Load(); fn != nil {
+		(*fn)()
 		return
 	}
 


### PR DESCRIPTION
## Problem

On Windows the platform convention for tray icons is: single click (or right
click) shows the menu, double click performs the primary action - typically
showing the main window. Explorer's own icons, Qt's `QSystemTrayIcon`
(`ActivationReason: DoubleClick`), and Electron's Tray (`double-click` event)
all expose this. systray currently offers `SetOnTapped`/`SetOnTappedSecondary`
(added in #98) but no way to distinguish a double click, so a Go tray app
cannot implement the standard "double-click opens the app" pattern.

This was requested in #97, which was closed as a likely duplicate of #23 with
the concern that only Windows supports double-click. That is true - and this
patch scopes the behavior accordingly, the same way parts of the existing API
are already platform-scoped (for example `SetRemovalAllowed` only has an
effect on macOS).

## Fix

Following the same shared-setter-plus-platform-dispatch pattern as #98:

- `systray.go`: add `SetOnDoubleTapped(f func())`. The handler is stored in an
  `atomic.Pointer` because on Windows it is read on the message-pump thread
  while being set from the onReady goroutine (the existing `tappedLeft` /
  `tappedRight` funcs are only exercised by value on the same thread). The doc
  comment states the handler is only ever invoked on Windows and runs on the
  pump thread.
- `systray_windows.go`: handle `WM_LBUTTONDBLCLK` and dispatch to the handler,
  falling back to showing the menu when no handler is set.
- When a double-tap handler is set and no single-tap handler is, a bare left
  click intentionally does nothing: Windows delivers `WM_LBUTTONDOWN` for the
  first click of every double click, and popping the menu on it makes the menu
  flash open and steal focus mid-double-click. Apps that want both bind both
  handlers; apps that bind neither keep today's behavior exactly.

macOS and Linux are untouched: the setter exists (API parity, no build tags
needed downstream) but nothing invokes it, matching the platform-scoped
precedent above.

Tested on Windows 10 (LTSC 2021): double-click raises the app window,
single click with only the double handler bound no longer flashes the menu,
right-click menu unchanged, and behavior with no handlers bound is identical
to master.
