### PR TITLE
fix(unix): Stop emitting LayoutUpdated event for property-update-only changes

### DIFF
--- a/systray.go
+++ b/systray.go
@@ -20,6 +20,10 @@ var (
 	currentID        atomic.Uint32
 	quitOnce         sync.Once
 
+	// optimizeMenuUpdates gates suppression of LayoutUpdated for property-only
+	// menu changes on Linux. See SetOptimizeMenuUpdates.
+	optimizeMenuUpdates atomic.Bool
+
 	// TrayOpenedCh receives an entry each time the system tray menu is opened.
 	TrayOpenedCh = make(chan struct{})
 )
@@ -165,6 +169,15 @@ func SetOnTapped(f func()) {
 
 func SetOnSecondaryTapped(f func()) {
 	tappedRight = f
+}
+
+// SetOptimizeMenuUpdates, on Linux, stops property-only changes (SetTitle,
+// SetIcon, Enable, Check, Show, etc.) from also emitting LayoutUpdated, which
+// otherwise makes hosts re-fetch the whole menu and close any open submenu.
+// The default (false) keeps emitting it for clients that only watch
+// LayoutUpdated. Structural changes always emit it. No effect on other platforms.
+func SetOptimizeMenuUpdates(optimize bool) {
+	optimizeMenuUpdates.Store(optimize)
 }
 
 // AddMenuItem adds a menu item with the designated title and tooltip.

--- a/systray.go
+++ b/systray.go
@@ -20,10 +20,6 @@ var (
 	currentID        atomic.Uint32
 	quitOnce         sync.Once
 
-	// optimizeMenuUpdates gates suppression of LayoutUpdated for property-only
-	// menu changes on Linux. See SetOptimizeMenuUpdates.
-	optimizeMenuUpdates atomic.Bool
-
 	// TrayOpenedCh receives an entry each time the system tray menu is opened.
 	TrayOpenedCh = make(chan struct{})
 )
@@ -169,15 +165,6 @@ func SetOnTapped(f func()) {
 
 func SetOnSecondaryTapped(f func()) {
 	tappedRight = f
-}
-
-// SetOptimizeMenuUpdates, on Linux, stops property-only changes (SetTitle,
-// SetIcon, Enable, Check, Show, etc.) from also emitting LayoutUpdated, which
-// otherwise makes hosts re-fetch the whole menu and close any open submenu.
-// The default (false) keeps emitting it for clients that only watch
-// LayoutUpdated. Structural changes always emit it. No effect on other platforms.
-func SetOptimizeMenuUpdates(optimize bool) {
-	optimizeMenuUpdates.Store(optimize)
 }
 
 // AddMenuItem adds a menu item with the designated title and tooltip.

--- a/systray_menu_unix.go
+++ b/systray_menu_unix.go
@@ -23,9 +23,6 @@ func (item *MenuItem) SetIcon(iconBytes []byte) {
 	if exists {
 		m.V1["icon-data"] = dbus.MakeVariant(iconBytes)
 		emitItemPropertiesUpdated(int32(item.id), m.V1)
-		// Property-only change; per spec LayoutUpdated isn't required here,
-		// but kept as a fallback for clients that only watch LayoutUpdated.
-		refresh(false)
 	}
 }
 
@@ -84,7 +81,7 @@ func (t *tray) GetLayout(parentID int32, recursionDepth int32, propertyNames []s
 			depth = 1
 			go func() {
 				time.Sleep(150 * time.Millisecond)
-				refresh(true)
+				refresh()
 			}()
 		}
 		// return copy of menu layout to prevent panic from cuncurrent access to layout
@@ -256,9 +253,6 @@ func addOrUpdateMenuItem(item *MenuItem) {
 	applyItemToLayout(item, layout)
 	if exists {
 		emitItemPropertiesUpdated(int32(item.id), layout.V1)
-		// Property-only change on an existing item; per spec LayoutUpdated isn't required here,
-		// but kept as a fallback for clients that only watch LayoutUpdated.
-		refresh(false)
 	} else {
 		// We've added "children-display", that's a property change
 		if parentForChildrenDisplayUpdate != nil {
@@ -266,7 +260,7 @@ func addOrUpdateMenuItem(item *MenuItem) {
 		}
 		// New item appended to a parent's children,
 		// that's a structural change, so LayoutUpdated signal is required
-		refresh(true)
+		refresh()
 	}
 }
 
@@ -283,7 +277,7 @@ func addSeparator(id uint32, parent uint32) {
 		V2: []dbus.Variant{},
 	}
 	menu.V2 = append(menu.V2, dbus.MakeVariant(layout))
-	refresh(true)
+	refresh()
 }
 
 func applyItemToLayout(in *MenuItem, out *menuLayout) {
@@ -360,7 +354,7 @@ func removeMenuItem(item *MenuItem) {
 
 	if items, removed := removeSubLayout(int32(item.id), parent.V2); removed {
 		parent.V2 = items
-		refresh(true)
+		refresh()
 	}
 }
 
@@ -371,9 +365,6 @@ func hideMenuItem(item *MenuItem) {
 	if exists {
 		m.V1["visible"] = dbus.MakeVariant(false)
 		emitItemPropertiesUpdated(int32(item.id), m.V1)
-		// Property-only change; per spec LayoutUpdated isn't required here,
-		// but kept as a fallback for clients that only watch LayoutUpdated.
-		refresh(false)
 	}
 }
 
@@ -384,9 +375,6 @@ func showMenuItem(item *MenuItem) {
 	if exists {
 		m.V1["visible"] = dbus.MakeVariant(true)
 		emitItemPropertiesUpdated(int32(item.id), m.V1)
-		// Property-only change; per spec LayoutUpdated isn't required here,
-		// but kept as a fallback for clients that only watch LayoutUpdated.
-		refresh(false)
 	}
 }
 
@@ -414,12 +402,7 @@ func emitItemPropertiesUpdated(id int32, props map[string]dbus.Variant) {
 	}
 }
 
-// refresh emits the dbusmenu LayoutUpdated signal. layoutUpdated is false for
-// property-only changes, which are suppressed once SetOptimizeMenuUpdates is on.
-func refresh(layoutUpdated bool) {
-	if !layoutUpdated && optimizeMenuUpdates.Load() {
-		return
-	}
+func refresh() {
 	instance.lock.Lock()
 	defer instance.lock.Unlock()
 	if instance.conn == nil || instance.menuProps == nil {
@@ -449,5 +432,5 @@ func resetMenu() {
 	instance.menu = &menuLayout{}
 	instance.menuVersion++
 	firstGetLayoutDone = false
-	refresh(true)
+	refresh()
 }

--- a/systray_menu_unix.go
+++ b/systray_menu_unix.go
@@ -25,7 +25,7 @@ func (item *MenuItem) SetIcon(iconBytes []byte) {
 		emitItemPropertiesUpdated(int32(item.id), m.V1)
 		// Property-only change; per spec LayoutUpdated isn't required here,
 		// but kept as a fallback for clients that only watch LayoutUpdated.
-		refresh()
+		refresh(false)
 	}
 }
 
@@ -84,7 +84,7 @@ func (t *tray) GetLayout(parentID int32, recursionDepth int32, propertyNames []s
 			depth = 1
 			go func() {
 				time.Sleep(150 * time.Millisecond)
-				refresh()
+				refresh(true)
 			}()
 		}
 		// return copy of menu layout to prevent panic from cuncurrent access to layout
@@ -258,7 +258,7 @@ func addOrUpdateMenuItem(item *MenuItem) {
 		emitItemPropertiesUpdated(int32(item.id), layout.V1)
 		// Property-only change on an existing item; per spec LayoutUpdated isn't required here,
 		// but kept as a fallback for clients that only watch LayoutUpdated.
-		refresh()
+		refresh(false)
 	} else {
 		// We've added "children-display", that's a property change
 		if parentForChildrenDisplayUpdate != nil {
@@ -266,7 +266,7 @@ func addOrUpdateMenuItem(item *MenuItem) {
 		}
 		// New item appended to a parent's children,
 		// that's a structural change, so LayoutUpdated signal is required
-		refresh()
+		refresh(true)
 	}
 }
 
@@ -283,7 +283,7 @@ func addSeparator(id uint32, parent uint32) {
 		V2: []dbus.Variant{},
 	}
 	menu.V2 = append(menu.V2, dbus.MakeVariant(layout))
-	refresh()
+	refresh(true)
 }
 
 func applyItemToLayout(in *MenuItem, out *menuLayout) {
@@ -360,7 +360,7 @@ func removeMenuItem(item *MenuItem) {
 
 	if items, removed := removeSubLayout(int32(item.id), parent.V2); removed {
 		parent.V2 = items
-		refresh()
+		refresh(true)
 	}
 }
 
@@ -373,7 +373,7 @@ func hideMenuItem(item *MenuItem) {
 		emitItemPropertiesUpdated(int32(item.id), m.V1)
 		// Property-only change; per spec LayoutUpdated isn't required here,
 		// but kept as a fallback for clients that only watch LayoutUpdated.
-		refresh()
+		refresh(false)
 	}
 }
 
@@ -386,7 +386,7 @@ func showMenuItem(item *MenuItem) {
 		emitItemPropertiesUpdated(int32(item.id), m.V1)
 		// Property-only change; per spec LayoutUpdated isn't required here,
 		// but kept as a fallback for clients that only watch LayoutUpdated.
-		refresh()
+		refresh(false)
 	}
 }
 
@@ -414,7 +414,12 @@ func emitItemPropertiesUpdated(id int32, props map[string]dbus.Variant) {
 	}
 }
 
-func refresh() {
+// refresh emits the dbusmenu LayoutUpdated signal. layoutUpdated is false for
+// property-only changes, which are suppressed once SetOptimizeMenuUpdates is on.
+func refresh(layoutUpdated bool) {
+	if !layoutUpdated && optimizeMenuUpdates.Load() {
+		return
+	}
 	instance.lock.Lock()
 	defer instance.lock.Unlock()
 	if instance.conn == nil || instance.menuProps == nil {
@@ -444,5 +449,5 @@ func resetMenu() {
 	instance.menu = &menuLayout{}
 	instance.menuVersion++
 	firstGetLayoutDone = false
-	refresh()
+	refresh(true)
 }


### PR DESCRIPTION
Property-only changes (SetTitle/SetIcon/Enable/Show/etc.) emitted both ItemsPropertiesUpdated and, as a fallback, LayoutUpdated (since 3aca44e). LayoutUpdated can cause the host to re-fetch the whole menu, re-drawing with any open submenu closed and also adding latency.

Drop the fallback as it is an unnecessary event that triggers a rougher UX for some clients.