### PR TITLE
fix(unix): Serve all 16 StatusNotifierItem properties

### DIFF
--- a/systray_unix.go
+++ b/systray_unix.go
@@ -398,6 +398,48 @@ func (t *tray) createPropSpec() map[string]map[string]*prop.Prop {
 				Emit:     prop.EmitTrue,
 				Callback: nil,
 			},
+			// The SNI spec says an item "must provide" all 16 properties,
+			// so we serve the rest with empty defaults even though we don't
+			// otherwise use them. Without this, a host that reads every
+			// property gets an UnknownProperty error, which can crash strict
+			// clients (e.g. Qtile).
+			// https://www.freedesktop.org/wiki/Specifications/StatusNotifierItem/StatusNotifierItem/
+			"WindowId": {
+				Value:    int32(0), // 0 means "not interested" per the SNI spec
+				Writable: false,
+				Emit:     prop.EmitTrue,
+				Callback: nil,
+			},
+			"OverlayIconName": {
+				Value:    "",
+				Writable: false,
+				Emit:     prop.EmitTrue,
+				Callback: nil,
+			},
+			"OverlayIconPixmap": {
+				Value:    []PX{},
+				Writable: false,
+				Emit:     prop.EmitTrue,
+				Callback: nil,
+			},
+			"AttentionIconName": {
+				Value:    "",
+				Writable: false,
+				Emit:     prop.EmitTrue,
+				Callback: nil,
+			},
+			"AttentionIconPixmap": {
+				Value:    []PX{},
+				Writable: false,
+				Emit:     prop.EmitTrue,
+				Callback: nil,
+			},
+			"AttentionMovieName": {
+				Value:    "",
+				Writable: false,
+				Emit:     prop.EmitTrue,
+				Callback: nil,
+			},
 		}}
 }
 

--- a/systray_unix.go
+++ b/systray_unix.go
@@ -398,12 +398,6 @@ func (t *tray) createPropSpec() map[string]map[string]*prop.Prop {
 				Emit:     prop.EmitTrue,
 				Callback: nil,
 			},
-			// The SNI spec says an item "must provide" all 16 properties,
-			// so we serve the rest with empty defaults even though we don't
-			// otherwise use them. Without this, a host that reads every
-			// property gets an UnknownProperty error, which can crash strict
-			// clients (e.g. Qtile).
-			// https://www.freedesktop.org/wiki/Specifications/StatusNotifierItem/StatusNotifierItem/
 			"WindowId": {
 				Value:    int32(0), // 0 means "not interested" per the SNI spec
 				Writable: false,

--- a/systray_unix_test.go
+++ b/systray_unix_test.go
@@ -1,0 +1,18 @@
+//go:build (linux || freebsd || openbsd || netbsd) && !android
+
+package systray
+
+import (
+	"testing"
+
+	"fyne.io/systray/internal/generated/notifier"
+)
+
+func TestPropSpecCoversIntrospection(t *testing.T) {
+	served := instance.createPropSpec()["org.kde.StatusNotifierItem"]
+	for _, p := range notifier.IntrospectDataStatusNotifierItem.Properties {
+		if _, ok := served[p.Name]; !ok {
+			t.Errorf("property %q is advertised via introspection but not served", p.Name)
+		}
+	}
+}


### PR DESCRIPTION
Systray currently advertises 16 SNI properties, but only serves the 10 that are actively used. When running on a Qtile desktop, the SNI plugin crashed on receipt of an UnknownProperty error while polling all properties that were identified by introspection.

Serve the remaining required properties with default empty values to remain compliant.